### PR TITLE
Use debug() instead of console.error()

### DIFF
--- a/https-proxy-agent.js
+++ b/https-proxy-agent.js
@@ -113,11 +113,11 @@ function connect (req, _opts, fn) {
   }
 
   function onclose (err) {
-    console.error('onclose');
+    debug('onclose had error', err);
   }
 
-  function onend (err) {
-    console.error('onend');
+  function onend () {
+    debug('onend');
   }
 
   function onerror (err) {


### PR DESCRIPTION
Silents the module by default and also prints the has_error
boolean in case its wanted. Ideally there would be a way
to catch 'end' and 'close' upstream.
