### PR TITLE
Add support for "timeout"

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -27,7 +27,7 @@ const debug = createDebug('https-proxy-agent:agent');
 export default class HttpsProxyAgent extends Agent {
 	private secureProxy: boolean;
 	private proxy: HttpsProxyAgentOptions;
-	public timeout: number | null
+	public timeout: number | null;
 	
 	constructor(_opts: string | HttpsProxyAgentOptions) {
 		let opts: HttpsProxyAgentOptions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ namespace createHttpsProxyAgent {
 		host?: string | null;
 		path?: string | null;
 		port?: string | number | null;
+		timeout?: number;
 	}
 
 	export interface HttpsProxyAgentOptions


### PR DESCRIPTION
This changes makes https-proxy-agent respect the timeout parameter, so #1 is fixed.

Otherwise, the agent waits for unresponsive servers forever.

This does not take care of giving a clear error message yet.