### PR TITLE
Add support for "connectHost" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The `options` argument may either be a string URI of the proxy server to use, or
   * `host` - String - Proxy host to connect to (may use `hostname` as well). Required.
   * `port` - Number - Proxy port to connect to. Required.
   * `protocol` - String - If `https:`, then use TLS to connect to the proxy.
+  * `connectHost` - String - Overridden host to be sent on the HTTP CONNECT method. 
   * `headers` - Object - Additional HTTP headers to be sent on the HTTP CONNECT method.
   * Any other options given are passed to the `net.connect()`/`tls.connect()` functions.
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -99,7 +99,7 @@ export default class HttpsProxyAgent extends Agent {
 		}
 
 		const headers: OutgoingHttpHeaders = { ...proxy.headers };
-		const hostname = `${opts.host}:${opts.port}`;
+		const hostname = `${proxy.connectHost || opts.host}:${opts.port}`;
 		let payload = `CONNECT ${hostname} HTTP/1.1\r\n`;
 
 		// Inject the `Proxy-Authorization` header if necessary.
@@ -111,7 +111,8 @@ export default class HttpsProxyAgent extends Agent {
 
 		// The `Host` header should only include the port
 		// number when it is not the default port.
-		let { host, port, secureEndpoint } = opts;
+		let { port, secureEndpoint } = opts;
+		let host = proxy.connectHost || opts.host;
 		if (!isDefaultPort(port, secureEndpoint)) {
 			host += `:${port}`;
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ namespace createHttpsProxyAgent {
 	interface BaseHttpsProxyAgentOptions {
 		headers?: OutgoingHttpHeaders;
 		secureProxy?: boolean;
+		connectHost?: string | null;
 		host?: string | null;
 		path?: string | null;
 		port?: string | number | null;


### PR DESCRIPTION
I need to override the CONNECT host so that proxied requests are routed to an alternative host and the host name of the original request is still used for SNI. This is not a novel thing for an HTTP client. For example, this can be achieved with Curl "--connect-to":

```
https_proxy=http://proxyhost:8888 \
  curl https://sever-name \
  --connect-to server-name:443:server-alt-name:443
```

With this change, the same can now be achieved using Https Proxy Agent. For example, using Axios:

```js
axios.request({
  url: 'https://server-name',
  httpsAgent: new HttpsProxyAgent({
    host: 'proxyhost',
    port: '8888',
    connectHost: 'server-alt-name', 
  }),
});
```

Why would I want to do this? I'm building a new gateway in front of legacy infrastructure that is expensive and risky to change. This approach allows me to connect to the legacy service using it's alt name without making any changes to it.