### PR TITLE
Add ability to set custom Connection header

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -117,7 +117,7 @@ export default class HttpsProxyAgent extends Agent {
 		}
 		headers.Host = host;
 
-		headers.Connection = 'close';
+		headers.Connection = headers.Connection || 'close';
 		for (const name of Object.keys(headers)) {
 			payload += `${name}: ${headers[name]}\r\n`;
 		}

--- a/test/test.js
+++ b/test/test.js
@@ -312,6 +312,30 @@ describe('HttpsProxyAgent', function() {
 
 			http.get(opts);
 		});
+
+		it('should allow set custom Connection header', function(done) {
+			server.once('connect', function(req, socket, head) {
+				assert.equal('CONNECT', req.method);
+				assert.equal('Keep-Alive', req.headers.connection);
+				socket.destroy();
+				done();
+			});
+
+			let uri = `http://localhost:${serverPort}`;
+			let proxyOpts = url.parse(uri);
+			proxyOpts.headers = {
+				Connection: 'Keep-Alive'
+			};
+			let agent = new HttpsProxyAgent(proxyOpts);
+
+			let opts = {};
+			// `host` and `port` don't really matter since the proxy will reject anyways
+			opts.host = 'localhost';
+			opts.port = 80;
+			opts.agent = agent;
+
+			http.get(opts);
+		});
 	});
 
 	describe('"https" module', function() {


### PR DESCRIPTION
Reason: some proxy servers close proxy tunnel before request has been finished, because CONNECT request contains Connection: close header. This solution will useful when configuration of proxy server can't be changed (hello enterprise).