### PR TITLE
Fix imports & update agent-base ver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "https-proxy-agent",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "An HTTP(s) proxy `http.Agent` implementation for HTTPS",
   "main": "dist/index",
   "types": "dist/index",
@@ -30,7 +30,7 @@
     "url": "https://github.com/TooTallNate/node-https-proxy-agent/issues"
   },
   "dependencies": {
-    "agent-base": "6",
+    "agent-base": "6.0.2",
     "debug": "4"
   },
   "devDependencies": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,5 +1,5 @@
-import net from 'net';
-import tls from 'tls';
+import * as net from 'net';
+import * as tls from 'tls';
 import url from 'url';
 import assert from 'assert';
 import createDebug from 'debug';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import net from 'net';
-import tls from 'tls';
+import * as net from 'net';
+import * as tls from 'tls';
 import { Url } from 'url';
 import { AgentOptions } from 'agent-base';
 import { OutgoingHttpHeaders } from 'http';


### PR DESCRIPTION
Changes:
- Fixes "no default export error" issue for downstream projects, also removes the `allowSyntheticDefaultImports` workaround.
- Update agent-base@6.0.2 to apply: https://github.com/TooTallNate/node-agent-base/pull/57.  But currently **blocked** by: https://github.com/TooTallNate/node-agent-base/pull/55

