### PR TITLE
Support IPv6 proxy URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "agent-base": "6",
-    "debug": "4"
+    "debug": "4",
+    "ip-regex": "5"
   },
   "devDependencies": {
     "@types/debug": "4",


### PR DESCRIPTION
When proxying, the agent sends a `CONNECT <host>:<port>` message. IPv6 with a port suffix is ambiguous, so servers usually require the address to be bracketed (e.g. `::1:8080` vs `[::1]:8080`). This commit checks if the host the agent is proxying to is an unbracketed IPv6, and wraps it in brackets. I'm using the `ip-regex` package for this, which simply contains a bunch of regular expressions that match IP addresses.