### PR TITLE
Fix ALPN protocol identifier for HTTP/1.1

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -61,7 +61,7 @@ export default class HttpsProxyAgent extends Agent {
 		// ALPN is supported by Node.js >= v5.
 		// attempt to negotiate http/1.1 for proxy servers that support http/2
 		if (this.secureProxy && !('ALPNProtocols' in proxy)) {
-			proxy.ALPNProtocols = ['http 1.1'];
+			proxy.ALPNProtocols = ['http/1.1'];
 		}
 
 		if (proxy.host && proxy.path) {


### PR DESCRIPTION
The ALPN identifier that https-proxy-agent uses for TLS is not correct. The IANA registry of valid values is [here](https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids) and you can see that for HTTP/1.1 it specifically has to be byte-identical to `http/1.1` (note the slash) and `http 1.1` as used here is not a valid identifier.

Because of this, ALPN negotiation always fails right now. Normally that's fine, because most TLS servers just fall back to plain HTTP anyway, but as of Node v19+, Node.js servers that use ALPN will reject all incoming connections that try to use ALPN but can't successfully agree on a protocol (according to the spec, everybody should be doing this really). Quite a lot of proxy servers do use ALPN, because it's effectively required to be able to use HTTP/2, so this may cause problems now that Node v20 is out (it breaks my tests, for one)

Anyway, it's fortunately a very quick and easy fix with no downside :smile: