### PR TITLE
[proxy-agent] Use "lru-cache@7"

### DIFF
--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -40,7 +40,7 @@
     "debug": "^4.3.4",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.1",
-    "lru-cache": "^8.0.5",
+    "lru-cache": "^7.14.1",
     "pac-proxy-agent": "^5.0.0",
     "proxy-from-env": "^1.1.0",
     "socks-proxy-agent": "^7.0.0"

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -40,7 +40,7 @@
     "debug": "^4.3.4",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.1",
-    "lru-cache": "^9.1.1",
+    "lru-cache": "^8.0.5",
     "pac-proxy-agent": "^5.0.0",
     "proxy-from-env": "^1.1.0",
     "socks-proxy-agent": "^7.0.0"

--- a/packages/proxy-agent/src/index.ts
+++ b/packages/proxy-agent/src/index.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import * as https from 'https';
-import { LRUCache } from 'lru-cache';
+import LRUCache from 'lru-cache';
 import { Agent, AgentConnectOpts } from 'agent-base';
 import createDebug from 'debug';
 import { getProxyForUrl } from 'proxy-from-env';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,8 +388,8 @@ importers:
         specifier: ^5.0.1
         version: link:../https-proxy-agent
       lru-cache:
-        specifier: ^9.1.1
-        version: 9.1.1
+        specifier: ^8.0.5
+        version: 8.0.5
       pac-proxy-agent:
         specifier: ^5.0.0
         version: link:../pac-proxy-agent
@@ -3731,9 +3731,15 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /lru-cache@8.0.5:
+    resolution: {integrity: sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==}
+    engines: {node: '>=16.14'}
+    dev: false
+
   /lru-cache@9.1.1:
     resolution: {integrity: sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==}
     engines: {node: 14 || >=16.14}
+    dev: true
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,8 +388,8 @@ importers:
         specifier: ^5.0.1
         version: link:../https-proxy-agent
       lru-cache:
-        specifier: ^8.0.5
-        version: 8.0.5
+        specifier: ^7.14.1
+        version: 7.14.1
       pac-proxy-agent:
         specifier: ^5.0.0
         version: link:../pac-proxy-agent
@@ -3731,9 +3731,9 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /lru-cache@8.0.5:
-    resolution: {integrity: sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==}
-    engines: {node: '>=16.14'}
+  /lru-cache@7.14.1:
+    resolution: {integrity: sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==}
+    engines: {node: '>=12'}
     dev: false
 
   /lru-cache@9.1.1:


### PR DESCRIPTION
ncc v0.24.0 has an issue parsing "lru-cache@9" and also "lru-cache@8" :/

```
ncc: Version 0.24.0
ncc: Compiling file index.js
ncc: Using typescript@4.9.5 (local user-provided)
Error: Module parse failed: Unexpected token (27:15)
File was processed with these loaders:
 * ../../node_modules/.pnpm/@vercel+ncc@0.24.0/node_modules/@vercel/ncc/dist/ncc/loaders/empty-loader.js
 * ../../node_modules/.pnpm/@vercel+ncc@0.24.0/node_modules/@vercel/ncc/dist/ncc/loaders/relocate-loader.js
 * ../../node_modules/.pnpm/@vercel+ncc@0.24.0/node_modules/@vercel/ncc/dist/ncc/loaders/shebang-loader.js
You may need an additional loader to handle the result of these loaders.
|     //@ts-ignore
|     AS = class AbortSignal {
>         onabort;
|         _onabort = [];
|         reason;
```