### PR TITLE
Update `@types/node` to v14.18.45

### DIFF
--- a/.changeset/silver-carpets-bow.md
+++ b/.changeset/silver-carpets-bow.md
@@ -1,0 +1,15 @@
+---
+'data-uri-to-buffer': patch
+'https-proxy-agent': patch
+'socks-proxy-agent': patch
+'http-proxy-agent': patch
+'pac-proxy-agent': patch
+'pac-resolver': patch
+'degenerator': patch
+'proxy-agent': patch
+'agent-base': patch
+'get-uri': patch
+'proxy': patch
+---
+
+Update `@types/node` to v14.18.45

--- a/packages/agent-base/package.json
+++ b/packages/agent-base/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/jest": "^29.5.1",
-    "@types/node": "^14.18.43",
+    "@types/node": "^14.18.45",
     "@types/semver": "^7.3.13",
     "@types/ws": "^6.0.4",
     "async-listen": "^2.1.0",

--- a/packages/data-uri-to-buffer/package.json
+++ b/packages/data-uri-to-buffer/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^27.0.2",
-    "@types/node": "^14.18.43",
+    "@types/node": "^14.18.45",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "tsconfig": "workspace:*",

--- a/packages/degenerator/package.json
+++ b/packages/degenerator/package.json
@@ -33,7 +33,7 @@
     "@types/escodegen": "^0.0.6",
     "@types/esprima": "^4.0.2",
     "@types/jest": "^29.5.1",
-    "@types/node": "^14.18.43",
+    "@types/node": "^14.18.45",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "tsconfig": "workspace:*",

--- a/packages/get-uri/package.json
+++ b/packages/get-uri/package.json
@@ -39,7 +39,7 @@
     "@types/fs-extra": "^8.1.2",
     "@types/ftpd": "^0.2.35",
     "@types/jest": "^29.5.1",
-    "@types/node": "^14.18.43",
+    "@types/node": "^14.18.45",
     "async-listen": "^2.1.0",
     "ftpd": "https://files-jg1s1zt9l.n8.io/ftpd-v0.2.14.tgz",
     "jest": "^29.5.0",

--- a/packages/http-proxy-agent/package.json
+++ b/packages/http-proxy-agent/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/jest": "^29.5.1",
-    "@types/node": "^14.18.43",
+    "@types/node": "^14.18.45",
     "async-listen": "^2.1.0",
     "jest": "^29.5.0",
     "proxy": "workspace:*",

--- a/packages/https-proxy-agent/package.json
+++ b/packages/https-proxy-agent/package.json
@@ -35,7 +35,7 @@
     "@types/async-retry": "^1.4.5",
     "@types/debug": "4",
     "@types/jest": "^29.5.1",
-    "@types/node": "^14.18.43",
+    "@types/node": "^14.18.45",
     "async-listen": "^2.1.0",
     "async-retry": "^1.3.3",
     "jest": "^29.5.0",

--- a/packages/pac-proxy-agent/package.json
+++ b/packages/pac-proxy-agent/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/jest": "^29.5.1",
-    "@types/node": "^14.18.43",
+    "@types/node": "^14.18.45",
     "async-listen": "^2.1.0",
     "jest": "^29.5.0",
     "proxy": "workspace:*",

--- a/packages/pac-resolver/package.json
+++ b/packages/pac-resolver/package.json
@@ -16,7 +16,7 @@
     "@types/ip": "^1.1.0",
     "@types/jest": "^29.5.1",
     "@types/netmask": "^1.0.30",
-    "@types/node": "^14.18.43",
+    "@types/node": "^14.18.45",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "tsconfig": "workspace:*",

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -45,7 +45,7 @@
     "@types/agent-base": "^4.2.0",
     "@types/debug": "^4.1.7",
     "@types/jest": "^29.5.1",
-    "@types/node": "^14.18.43",
+    "@types/node": "^14.18.45",
     "@types/proxy-from-env": "^1.0.1",
     "async-listen": "^2.1.0",
     "jest": "^29.5.0",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -42,7 +42,7 @@
     "@types/args": "^5.0.0",
     "@types/debug": "^4.1.7",
     "@types/jest": "^29.5.1",
-    "@types/node": "^14.18.43",
+    "@types/node": "^14.18.45",
     "async-listen": "^2.1.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",

--- a/packages/socks-proxy-agent/package.json
+++ b/packages/socks-proxy-agent/package.json
@@ -116,7 +116,7 @@
     "@types/debug": "^4.1.7",
     "@types/dns2": "^2.0.3",
     "@types/jest": "^29.5.1",
-    "@types/node": "^14.18.43",
+    "@types/node": "^14.18.45",
     "async-listen": "^2.1.0",
     "async-retry": "^1.3.3",
     "cacheable-lookup": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,10 @@ importers:
         version: 2.26.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.1
-        version: 5.59.1(@typescript-eslint/parser@5.59.1)(eslint@7.32.0)
+        version: 5.59.1(@typescript-eslint/parser@5.59.1)(eslint@7.32.0)(typescript@5.0.4)
       '@typescript-eslint/parser':
         specifier: ^5.59.1
-        version: 5.59.1(eslint@7.32.0)
+        version: 5.59.1(eslint@7.32.0)(typescript@5.0.4)
       eslint:
         specifier: ^7.32.0
         version: 7.32.0
@@ -42,8 +42,8 @@ importers:
         specifier: ^29.5.1
         version: 29.5.1
       '@types/node':
-        specifier: ^14.18.43
-        version: 14.18.43
+        specifier: ^14.18.45
+        version: 14.18.45
       '@types/semver':
         specifier: ^7.3.13
         version: 7.3.13
@@ -55,10 +55,10 @@ importers:
         version: 2.1.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@14.18.43)
+        version: 29.5.0(@types/node@14.18.45)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -75,14 +75,14 @@ importers:
         specifier: ^27.0.2
         version: 27.0.2
       '@types/node':
-        specifier: ^14.18.43
-        version: 14.18.43
+        specifier: ^14.18.45
+        version: 14.18.45
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@14.18.43)
+        version: 29.5.0(@types/node@14.18.45)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -115,14 +115,14 @@ importers:
         specifier: ^29.5.1
         version: 29.5.1
       '@types/node':
-        specifier: ^14.18.43
-        version: 14.18.43
+        specifier: ^14.18.45
+        version: 14.18.45
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@14.18.43)
+        version: 29.5.0(@types/node@14.18.45)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -158,8 +158,8 @@ importers:
         specifier: ^29.5.1
         version: 29.5.1
       '@types/node':
-        specifier: ^14.18.43
-        version: 14.18.43
+        specifier: ^14.18.45
+        version: 14.18.45
       async-listen:
         specifier: ^2.1.0
         version: 2.1.0
@@ -168,13 +168,13 @@ importers:
         version: '@files-jg1s1zt9l.n8.io/ftpd-v0.2.14.tgz'
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@14.18.43)
+        version: 29.5.0(@types/node@14.18.45)
       st:
         specifier: ^1.2.2
         version: 1.2.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -198,20 +198,20 @@ importers:
         specifier: ^29.5.1
         version: 29.5.1
       '@types/node':
-        specifier: ^14.18.43
-        version: 14.18.43
+        specifier: ^14.18.45
+        version: 14.18.45
       async-listen:
         specifier: ^2.1.0
         version: 2.1.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@14.18.43)
+        version: 29.5.0(@types/node@14.18.45)
       proxy:
         specifier: workspace:*
         version: link:../proxy
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -238,8 +238,8 @@ importers:
         specifier: ^29.5.1
         version: 29.5.1
       '@types/node':
-        specifier: ^14.18.43
-        version: 14.18.43
+        specifier: ^14.18.45
+        version: 14.18.45
       async-listen:
         specifier: ^2.1.0
         version: 2.1.0
@@ -248,13 +248,13 @@ importers:
         version: 1.3.3
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@14.18.43)
+        version: 29.5.0(@types/node@14.18.45)
       proxy:
         specifier: workspace:*
         version: link:../proxy
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -293,14 +293,14 @@ importers:
         specifier: ^29.5.1
         version: 29.5.1
       '@types/node':
-        specifier: ^14.18.43
-        version: 14.18.43
+        specifier: ^14.18.45
+        version: 14.18.45
       async-listen:
         specifier: ^2.1.0
         version: 2.1.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@14.18.43)
+        version: 29.5.0(@types/node@14.18.45)
       proxy:
         specifier: workspace:*
         version: link:../proxy
@@ -309,7 +309,7 @@ importers:
         version: 0.0.6
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -339,14 +339,14 @@ importers:
         specifier: ^1.0.30
         version: 1.0.30
       '@types/node':
-        specifier: ^14.18.43
-        version: 14.18.43
+        specifier: ^14.18.45
+        version: 14.18.45
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@14.18.43)
+        version: 29.5.0(@types/node@14.18.45)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -376,17 +376,17 @@ importers:
         specifier: ^29.5.1
         version: 29.5.1
       '@types/node':
-        specifier: ^14.18.43
-        version: 14.18.43
+        specifier: ^14.18.45
+        version: 14.18.45
       async-listen:
         specifier: ^2.1.0
         version: 2.1.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@14.18.43)
+        version: 29.5.0(@types/node@14.18.45)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -431,8 +431,8 @@ importers:
         specifier: ^29.5.1
         version: 29.5.1
       '@types/node':
-        specifier: ^14.18.43
-        version: 14.18.43
+        specifier: ^14.18.45
+        version: 14.18.45
       '@types/proxy-from-env':
         specifier: ^1.0.1
         version: 1.0.1
@@ -441,7 +441,7 @@ importers:
         version: 2.1.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@14.18.43)
+        version: 29.5.0(@types/node@14.18.45)
       proxy:
         specifier: workspace:*
         version: link:../proxy
@@ -450,7 +450,7 @@ importers:
         version: github.com/TooTallNate/socksv5/d937368b28e929396166d77a06d387a4a902bd51
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -483,8 +483,8 @@ importers:
         specifier: ^29.5.1
         version: 29.5.1
       '@types/node':
-        specifier: ^14.18.43
-        version: 14.18.43
+        specifier: ^14.18.45
+        version: 14.18.45
       async-listen:
         specifier: ^2.1.0
         version: 2.1.0
@@ -499,7 +499,7 @@ importers:
         version: 2.1.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@14.18.43)
+        version: 29.5.0(@types/node@14.18.45)
       proxy:
         specifier: workspace:*
         version: link:../proxy
@@ -508,7 +508,7 @@ importers:
         version: github.com/TooTallNate/socksv5/d937368b28e929396166d77a06d387a4a902bd51
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -1126,7 +1126,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       chalk: 4.1.2
       jest-message-util: 29.5.0
       jest-util: 29.5.0
@@ -1147,14 +1147,14 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@14.18.43)
+      jest-config: 29.5.0(@types/node@14.18.45)
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -1181,7 +1181,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       jest-mock: 29.5.0
     dev: true
 
@@ -1208,7 +1208,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@sinonjs/fake-timers': 10.0.2
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       jest-message-util: 29.5.0
       jest-mock: 29.5.0
       jest-util: 29.5.0
@@ -1241,7 +1241,7 @@ packages:
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.18
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -1329,7 +1329,7 @@ packages:
       '@jest/schemas': 29.4.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
@@ -1436,7 +1436,7 @@ packages:
     resolution: {integrity: sha512-8mrhPstU+ZX0Ugya8tl5DsDZ1I5ZwQzbL/8PA0z8Gj0k9nql7nkaMzmPVLj+l/nixWaliXi+EBiLA8bptw3z7Q==}
     dependencies:
       '@types/events': 3.0.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
     dev: true
 
   /@types/args@5.0.0:
@@ -1491,7 +1491,7 @@ packages:
   /@types/dns2@2.0.3:
     resolution: {integrity: sha512-sO14jUYelc2DzwHcCbwp7tZsZfB2x17/zIdHCAeUBINAz2cc36iVFLqCPCB7rn73CzoyoCmpkEnh1rA8C0puPw==}
     dependencies:
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
     dev: true
 
   /@types/escodegen@0.0.6:
@@ -1515,25 +1515,25 @@ packages:
   /@types/fs-extra@8.1.2:
     resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 14.18.45
     dev: true
 
   /@types/ftpd@0.2.35:
     resolution: {integrity: sha512-MeD8k0cx6wsmN84+59ex+2NCa0x5TgspdYWSDr91TWFutR4xITXD3ElExPvWJYmvS+HEvi1qiFc60NI5QKIVFQ==}
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 14.18.45
     dev: true
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
     dev: true
 
   /@types/ip@1.1.0:
     resolution: {integrity: sha512-dwNe8gOoF70VdL6WJBwVHtQmAX4RMd62M+mAB9HQFjG1/qiCLM/meRy95Pd14FYBbEDwCq7jgJs89cHpLBu4HQ==}
     dependencies:
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
     dev: true
 
   /@types/is-ci@3.0.0:
@@ -1592,8 +1592,8 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node@14.18.43:
-    resolution: {integrity: sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==}
+  /@types/node@14.18.45:
+    resolution: {integrity: sha512-Nd+FPp60jEaJpm4LAxuLT3wIhB4k0Jdj9DAP4ydqGyMg8DhE+7oM1we+QkwOkpMySTjcqcNfPOWY5kBuAOhkeg==}
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -1607,7 +1607,7 @@ packages:
   /@types/proxy-from-env@1.0.1:
     resolution: {integrity: sha512-luG++TFHyS61eKcfkR1CVV6a1GMNXDjtqEQIIfaSHax75xp0HU3SlezjOi1yqubJwrG8e9DeW59n6wTblIDwFg==}
     dependencies:
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
     dev: true
 
   /@types/retry@0.12.2:
@@ -1629,7 +1629,7 @@ packages:
   /@types/ws@6.0.4:
     resolution: {integrity: sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==}
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 14.18.45
     dev: true
 
   /@types/yargs-parser@21.0.0:
@@ -1642,7 +1642,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.59.1(@typescript-eslint/parser@5.59.1)(eslint@7.32.0):
+  /@typescript-eslint/eslint-plugin@5.59.1(@typescript-eslint/parser@5.59.1)(eslint@7.32.0)(typescript@5.0.4):
     resolution: {integrity: sha512-AVi0uazY5quFB9hlp2Xv+ogpfpk77xzsgsIEWyVS7uK/c7MZ5tw7ZPbapa0SbfkqE0fsAMkz5UwtgMLVk2BQAg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1654,22 +1654,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.0
-      '@typescript-eslint/parser': 5.59.1(eslint@7.32.0)
+      '@typescript-eslint/parser': 5.59.1(eslint@7.32.0)(typescript@5.0.4)
       '@typescript-eslint/scope-manager': 5.59.1
-      '@typescript-eslint/type-utils': 5.59.1(eslint@7.32.0)
-      '@typescript-eslint/utils': 5.59.1(eslint@7.32.0)
+      '@typescript-eslint/type-utils': 5.59.1(eslint@7.32.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.59.1(eslint@7.32.0)(typescript@5.0.4)
       debug: 4.3.4
       eslint: 7.32.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       semver: 7.3.8
-      tsutils: 3.21.0
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.59.1(eslint@7.32.0):
+  /@typescript-eslint/parser@5.59.1(eslint@7.32.0)(typescript@5.0.4):
     resolution: {integrity: sha512-nzjFAN8WEu6yPRDizIFyzAfgK7nybPodMNFGNH0M9tei2gYnYszRDqVA0xlnRjkl7Hkx2vYrEdb6fP2a21cG1g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1681,9 +1682,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.59.1
       '@typescript-eslint/types': 5.59.1
-      '@typescript-eslint/typescript-estree': 5.59.1
+      '@typescript-eslint/typescript-estree': 5.59.1(typescript@5.0.4)
       debug: 4.3.4
       eslint: 7.32.0
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1696,7 +1698,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.1
     dev: true
 
-  /@typescript-eslint/type-utils@5.59.1(eslint@7.32.0):
+  /@typescript-eslint/type-utils@5.59.1(eslint@7.32.0)(typescript@5.0.4):
     resolution: {integrity: sha512-ZMWQ+Oh82jWqWzvM3xU+9y5U7MEMVv6GLioM3R5NJk6uvP47kZ7YvlgSHJ7ERD6bOY7Q4uxWm25c76HKEwIjZw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1706,11 +1708,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.1
-      '@typescript-eslint/utils': 5.59.1(eslint@7.32.0)
+      '@typescript-eslint/typescript-estree': 5.59.1(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.59.1(eslint@7.32.0)(typescript@5.0.4)
       debug: 4.3.4
       eslint: 7.32.0
-      tsutils: 3.21.0
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1720,7 +1723,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.59.1:
+  /@typescript-eslint/typescript-estree@5.59.1(typescript@5.0.4):
     resolution: {integrity: sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1735,12 +1738,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0
+      tsutils: 3.21.0(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.59.1(eslint@7.32.0):
+  /@typescript-eslint/utils@5.59.1(eslint@7.32.0)(typescript@5.0.4):
     resolution: {integrity: sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1751,7 +1755,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.59.1
       '@typescript-eslint/types': 5.59.1
-      '@typescript-eslint/typescript-estree': 5.59.1
+      '@typescript-eslint/typescript-estree': 5.59.1(typescript@5.0.4)
       eslint: 7.32.0
       eslint-scope: 5.1.1
       semver: 7.3.8
@@ -3384,7 +3388,7 @@ packages:
       '@jest/expect': 29.5.0
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -3404,7 +3408,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.5.0(@types/node@14.18.43):
+  /jest-cli@29.5.0(@types/node@14.18.45):
     resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -3421,7 +3425,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.5.0(@types/node@14.18.43)
+      jest-config: 29.5.0(@types/node@14.18.45)
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
@@ -3432,7 +3436,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.5.0(@types/node@14.18.43):
+  /jest-config@29.5.0(@types/node@14.18.45):
     resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -3447,7 +3451,7 @@ packages:
       '@babel/core': 7.21.4
       '@jest/test-sequencer': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       babel-jest: 29.5.0(@babel/core@7.21.4)
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -3516,7 +3520,7 @@ packages:
       '@jest/environment': 29.5.0
       '@jest/fake-timers': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       jest-mock: 29.5.0
       jest-util: 29.5.0
     dev: true
@@ -3537,7 +3541,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@types/graceful-fs': 4.1.6
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -3588,7 +3592,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       jest-util: 29.5.0
     dev: true
 
@@ -3643,7 +3647,7 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -3674,7 +3678,7 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -3729,7 +3733,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -3754,7 +3758,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -3766,13 +3770,13 @@ packages:
     resolution: {integrity: sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 14.18.43
+      '@types/node': 14.18.45
       jest-util: 29.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.5.0(@types/node@14.18.43):
+  /jest@29.5.0(@types/node@14.18.45):
     resolution: {integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -3785,7 +3789,7 @@ packages:
       '@jest/core': 29.5.0
       '@jest/types': 29.5.0
       import-local: 3.1.0
-      jest-cli: 29.5.0(@types/node@14.18.43)
+      jest-cli: 29.5.0(@types/node@14.18.45)
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -4928,7 +4932,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-jest@29.1.0(jest@29.5.0)(typescript@5.0.4):
+  /ts-jest@29.1.0(@babel/core@7.21.4)(jest@29.5.0)(typescript@5.0.4):
     resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -4949,9 +4953,10 @@ packages:
       esbuild:
         optional: true
     dependencies:
+      '@babel/core': 7.21.4
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@14.18.43)
+      jest: 29.5.0(@types/node@14.18.45)
       jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -4969,13 +4974,14 @@ packages:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
     dev: false
 
-  /tsutils@3.21.0:
+  /tsutils@3.21.0(typescript@5.0.4):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
+      typescript: 5.0.4
     dev: true
 
   /tty-table@4.2.1:


### PR DESCRIPTION
Includes [this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65408), so that `http.Agent` properly extends from `EventEmitter`.