### PR TITLE
Add servername to tls options when connecting in DIRECT

### DIFF
--- a/.changeset/stupid-queens-listen.md
+++ b/.changeset/stupid-queens-listen.md
@@ -1,0 +1,5 @@
+---
+'pac-proxy-agent': patch
+---
+
+Add `servername` to tls connection options when pac-proxy-agent results in DIRECT connection

--- a/packages/pac-proxy-agent/src/index.ts
+++ b/packages/pac-proxy-agent/src/index.ts
@@ -232,7 +232,15 @@ export class PacProxyAgent<Uri extends string> extends Agent {
 
 			if (type === 'DIRECT') {
 				// Direct connection to the destination endpoint
-				socket = secureEndpoint ? tls.connect(opts) : net.connect(opts);
+				if (secureEndpoint) {
+					const servername = opts.servername || opts.host;
+					socket = tls.connect({
+						...opts,
+						servername: (!servername || net.isIP(servername)) ? undefined : servername,
+					});
+				} else {
+					socket = net.connect(opts);
+				}
 			} else if (type === 'SOCKS' || type === 'SOCKS5') {
 				// Use a SOCKSv5h proxy
 				agent = new SocksProxyAgent(`socks://${target}`, this.opts);


### PR DESCRIPTION
This a recreation of [this PR](https://github.com/TooTallNate/node-pac-proxy-agent/pull/19) from the original repo, with adjustments to match the implementation in other proxy agents.
I had an issue getting an ssl handshake failure error using a PAC based proxy configuration. Turns out `servername` must be provided to tls.connect(). I saw you had had it in your other "...-proxy-agent" so I just added the same here