### PR TITLE
[proxy-agent] Support for `getProxyForUrl` option

### DIFF
--- a/.changeset/odd-mirrors-nail.md
+++ b/.changeset/odd-mirrors-nail.md
@@ -1,0 +1,5 @@
+---
+'proxy-agent': patch
+---
+
+Support for `getProxyForUrl` option, to provide proxy address dynamically per different URLs

--- a/.changeset/odd-mirrors-nail.md
+++ b/.changeset/odd-mirrors-nail.md
@@ -1,5 +1,5 @@
 ---
-'proxy-agent': patch
+'proxy-agent': minor
 ---
 
 Support for `getProxyForUrl` option, to provide proxy address dynamically per different URLs

--- a/packages/proxy-agent/src/index.ts
+++ b/packages/proxy-agent/src/index.ts
@@ -3,7 +3,8 @@ import * as https from 'https';
 import LRUCache from 'lru-cache';
 import { Agent, AgentConnectOpts } from 'agent-base';
 import createDebug from 'debug';
-import { getProxyForUrl } from 'proxy-from-env';
+import { getProxyForUrl as envGetProxyForUrl } from 'proxy-from-env';
+import { URL } from "url";
 import { PacProxyAgent, PacProxyAgentOptions } from 'pac-proxy-agent';
 import { HttpProxyAgent, HttpProxyAgentOptions } from 'http-proxy-agent';
 import { HttpsProxyAgent, HttpsProxyAgentOptions } from 'https-proxy-agent';
@@ -20,6 +21,8 @@ const PROTOCOLS = [
 type ValidProtocol = (typeof PROTOCOLS)[number];
 
 type AgentConstructor = new (...args: never[]) => Agent;
+
+type GetProxyForUrlCallback = (url: string) => string;
 
 /**
  * Supported proxy types.
@@ -61,6 +64,12 @@ export type ProxyAgentOptions = HttpProxyAgentOptions<''> &
 		 * instance with the proxy agent options passed in.
 		 */
 		httpsAgent?: http.Agent;
+		/**
+		 * A callback for dynamic provision of proxy for url.
+		 * Defaults to standard proxy environment variables, 
+		 * see https://www.npmjs.com/package/proxy-from-env for details
+		 */
+		getProxyForUrl?: GetProxyForUrlCallback;
 	};
 
 /**
@@ -79,6 +88,7 @@ export class ProxyAgent extends Agent {
 	connectOpts?: ProxyAgentOptions;
 	httpAgent: http.Agent;
 	httpsAgent: http.Agent;
+	getProxyForUrl: GetProxyForUrlCallback;
 
 	constructor(opts?: ProxyAgentOptions) {
 		super(opts);
@@ -87,6 +97,7 @@ export class ProxyAgent extends Agent {
 		this.httpAgent = opts?.httpAgent || new http.Agent(opts);
 		this.httpsAgent =
 			opts?.httpsAgent || new https.Agent(opts as https.AgentOptions);
+		this.getProxyForUrl = opts?.getProxyForUrl || envGetProxyForUrl;
 	}
 
 	async connect(
@@ -97,7 +108,7 @@ export class ProxyAgent extends Agent {
 		const protocol = secureEndpoint ? 'https:' : 'http:';
 		const host = req.getHeader('host');
 		const url = new URL(req.path, `${protocol}//${host}`).href;
-		const proxy = getProxyForUrl(url);
+		const proxy = this.getProxyForUrl(url);
 
 		if (!proxy) {
 			debug('Proxy not enabled for URL: %o', url);

--- a/packages/proxy-agent/src/index.ts
+++ b/packages/proxy-agent/src/index.ts
@@ -4,7 +4,6 @@ import LRUCache from 'lru-cache';
 import { Agent, AgentConnectOpts } from 'agent-base';
 import createDebug from 'debug';
 import { getProxyForUrl as envGetProxyForUrl } from 'proxy-from-env';
-import { URL } from "url";
 import { PacProxyAgent, PacProxyAgentOptions } from 'pac-proxy-agent';
 import { HttpProxyAgent, HttpProxyAgentOptions } from 'http-proxy-agent';
 import { HttpsProxyAgent, HttpsProxyAgentOptions } from 'https-proxy-agent';

--- a/packages/proxy-agent/test/test.ts
+++ b/packages/proxy-agent/test/test.ts
@@ -251,5 +251,31 @@ describe('ProxyAgent', () => {
 				HttpsProxyAgent
 			);
 		});
+
+		it('should call provided function with getProxyForUrl option', async () => {
+			let gotCall = false;
+			let urlParameter = "";
+			httpsServer.once('request', function (req, res) {
+				res.end(JSON.stringify(req.headers));
+			});
+
+			const agent = new ProxyAgent({
+				rejectUnauthorized: false,
+				getProxyForUrl: (u) => {
+					gotCall = true;
+					urlParameter = u;
+					return httpsProxyServerUrl.href;
+				}
+			});
+			const requestUrl = new URL('/test', httpsServerUrl);
+			const res = await req(requestUrl, {
+				agent,
+				rejectUnauthorized: false,
+			});
+			const body = await json(res);
+			assert(httpsServerUrl.host === body.host);
+			assert(gotCall);
+			assert(requestUrl.href === urlParameter);
+		});
 	});
 });


### PR DESCRIPTION
This is a recreation of [this PR](https://github.com/TooTallNate/node-proxy-agent/pull/69) from the original repo.
This PR adds the option to provide a getProxyForUrl(url: string) => string function as an option to the ProxyAgent constructor.
We found it useful in places where proxy address is different for different hosts (and pac is not an option).