### PR TITLE
[agent-base] Allow for never relying on stack trace

### DIFF
--- a/.changeset/seven-horses-buy.md
+++ b/.changeset/seven-horses-buy.md
@@ -1,0 +1,5 @@
+---
+"agent-base": patch
+---
+
+[agent-base] Allow for never relying on stack trace

--- a/.changeset/seven-horses-buy.md
+++ b/.changeset/seven-horses-buy.md
@@ -2,4 +2,4 @@
 "agent-base": patch
 ---
 
-[agent-base] Allow for never relying on stack trace
+Allow for never relying on stack trace

--- a/packages/agent-base/src/helpers.ts
+++ b/packages/agent-base/src/helpers.ts
@@ -33,11 +33,14 @@ export function req(
 	url: string | URL,
 	opts: https.RequestOptions = {}
 ): ThenableRequest {
-	let req!: ThenableRequest;
+	const href = typeof url === 'string' ? url : url.href;
+	const req = (href.startsWith('https:') ? https : http).request(
+		url,
+		opts
+	) as ThenableRequest;
 	const promise = new Promise<http.IncomingMessage>((resolve, reject) => {
-		const href = typeof url === 'string' ? url : url.href;
-		req = (href.startsWith('https:') ? https : http)
-			.request(url, opts, resolve)
+		req
+			.once('response', resolve)
 			.once('error', reject)
 			.end() as ThenableRequest;
 	});

--- a/packages/agent-base/test/test.ts
+++ b/packages/agent-base/test/test.ts
@@ -38,6 +38,31 @@ describe('Agent (TypeScript)', () => {
 			assert(agent instanceof Agent);
 			assert(agent instanceof MyAgent);
 		});
+
+		it('should support explicit `protocol`', async () => {
+			class MyAgent extends Agent {
+				async connect() {
+					return http.globalAgent;
+				}
+			}
+			const agent = new MyAgent();
+
+			// Default checks stack trace
+			expect(agent.protocol).toEqual('http:');
+
+			agent.protocol = 'other:';
+			expect(agent.protocol).toEqual('other:');
+
+			// If we use this with `http.get()` then it should error
+			let err: Error | undefined;
+			try {
+				req(`http://127.0.0.1/foo`, { agent });
+			} catch (_err) {
+				err = _err as Error;
+			}
+			assert(err);
+			expect(err.message).toEqual('Protocol "http:" not supported. Expected "other:"');
+		});
 	});
 
 	describe('"http" module', () => {


### PR DESCRIPTION
During an HTTP request, if `opts.protocol` is set, then use that to determine the `secureEndpoint` value. Coupling that with an explicitly set `agent.protocol` in the instance (essentially "locking" it for use with either `http` or `https` module), then the agent will _never_ rely on the stack trace. By default it will still rely on the stack trace to allow for agent instances to be used with either `http` or `https` modules.

Also moved the internal props to an object using a symbol, instead of relying on underscore props.

Fixes #158.