### PR TITLE
Support dynamic headers for `https-proxy-agent`

### DIFF
--- a/.changeset/tidy-jobs-refuse.md
+++ b/.changeset/tidy-jobs-refuse.md
@@ -1,0 +1,5 @@
+---
+'https-proxy-agent': minor
+---
+
+"headers" option can now be a function

--- a/packages/https-proxy-agent/test/test.ts
+++ b/packages/https-proxy-agent/test/test.ts
@@ -188,7 +188,7 @@ describe('HttpsProxyAgent', () => {
 			assert.equal('ECONNREFUSED', err.code);
 		});
 
-		it('should allow custom proxy "headers"', async () => {
+		it('should allow custom proxy "headers" object', async () => {
 			const agent = new HttpsProxyAgent(serverUrl, {
 				headers: {
 					Foo: 'bar',
@@ -203,6 +203,29 @@ describe('HttpsProxyAgent', () => {
 			assert.equal('CONNECT', req.method);
 			assert.equal('bar', req.headers.foo);
 			socket.destroy();
+		});
+
+		it('should allow custom proxy "headers" function', async () => {
+			let count = 1;
+			const agent = new HttpsProxyAgent(serverUrl, {
+				headers: () => ({ number: count++ }),
+			});
+
+			const connectPromise = once(server, 'connect');
+			http.get({ agent });
+
+			const [req, socket] = await connectPromise;
+			assert.equal('CONNECT', req.method);
+			assert.equal('1', req.headers.number);
+			socket.destroy();
+
+			const connectPromise2 = once(server, 'connect');
+			http.get({ agent });
+
+			const [req2, socket2] = await connectPromise2;
+			assert.equal('CONNECT', req2.method);
+			assert.equal('2', req2.headers.number);
+			socket2.destroy();
 		});
 
 		it('should work with `keepAlive: true`', async () => {


### PR DESCRIPTION
Currently, the `headers` option can only be passed in when the HttpsProxyAgent is first created, so consumers can only set headers statically.

Typically, proxy headers are used to trace requests as they pass through multiple systems to enable log correlation. If someone wants to reuse a single HttpsProxyAgent for multiple requests, this isn't ideal.

This PR updates the `headers` option so that it can also be a function that returns an object, allowing consumers to set the proxy headers dynamically.

Companion PR to update HttpProxyAgent: #175