### PR TITLE
Support headers for `http-proxy-agent`

### DIFF
--- a/.changeset/unlucky-cows-listen.md
+++ b/.changeset/unlucky-cows-listen.md
@@ -1,0 +1,5 @@
+---
+'http-proxy-agent': minor
+---
+
+Added "headers" option

--- a/packages/http-proxy-agent/README.md
+++ b/packages/http-proxy-agent/README.md
@@ -30,8 +30,7 @@ API
 ### new HttpProxyAgent(proxy: string | URL, options?: HttpProxyAgentOptions)
 
 The `HttpProxyAgent` class implements an `http.Agent` subclass that connects
-to the specified "HTTP(s) proxy server" in order to proxy HTTP and/or WebSocket
-requests. This is achieved by using the [HTTP `CONNECT` method][CONNECT].
+to the specified "HTTP(s) proxy server" in order to proxy HTTP requests.
 
 The `proxy` argument is the URL for the proxy server.
 
@@ -39,8 +38,7 @@ The `options` argument accepts the usual `http.Agent` constructor options, and
 some additional properties:
 
  * `headers` - Object containing additional headers to send to the proxy server
-   in the `CONNECT` request. This may also be a function that returns a headers
-   object.
+   in each request. This may also be a function that returns a headers object.
   
    **NOTE:** If your proxy does not strip these headers from the request, they
    will also be sent to the destination server.

--- a/packages/http-proxy-agent/README.md
+++ b/packages/http-proxy-agent/README.md
@@ -24,6 +24,27 @@ http.get('http://nodejs.org/api/', { agent }, (res) => {
 });
 ```
 
+API
+---
+
+### new HttpProxyAgent(proxy: string | URL, options?: HttpProxyAgentOptions)
+
+The `HttpProxyAgent` class implements an `http.Agent` subclass that connects
+to the specified "HTTP(s) proxy server" in order to proxy HTTP and/or WebSocket
+requests. This is achieved by using the [HTTP `CONNECT` method][CONNECT].
+
+The `proxy` argument is the URL for the proxy server.
+
+The `options` argument accepts the usual `http.Agent` constructor options, and
+some additional properties:
+
+ * `headers` - Object containing additional headers to send to the proxy server
+   in the `CONNECT` request. This may also be a function that returns a headers
+   object.
+  
+   **NOTE:** If your proxy does not strip these headers from the request, they
+   will also be sent to the destination server.
+
 License
 -------
 

--- a/packages/http-proxy-agent/test/test.ts
+++ b/packages/http-proxy-agent/test/test.ts
@@ -176,6 +176,38 @@ describe('HttpProxyAgent', () => {
 			assert(err);
 			expect(err.code).toEqual('ECONNREFUSED');
 		});
+
+		it('should allow custom proxy "headers" object', async () => {
+			httpServer.once('request', (req, res) => {
+				res.end(JSON.stringify(req.headers));
+			});
+			const agent = new HttpProxyAgent(proxyUrl, {
+				headers: { Foo: 'bar' },
+			});
+
+			const res = await req(httpServerUrl, { agent });
+			const body = await json(res);
+			expect(body.foo).toEqual('bar');
+		});
+
+		it('should allow custom proxy "headers" function', async () => {
+			let count = 1;
+			httpServer.on('request', (req, res) => {
+				res.end(JSON.stringify(req.headers));
+			});
+			const agent = new HttpProxyAgent(proxyUrl, {
+				headers: () => ({ number: count++ }),
+			});
+
+			const res = await req(httpServerUrl, { agent });
+			const body = await json(res);
+			expect(body.number).toEqual('1');
+
+			const res2 = await req(httpServerUrl, { agent });
+			const body2 = await json(res2);
+			expect(body2.number).toEqual('2');
+		});
+
 		it('should not send a port number for the default port', async () => {
 			httpServer.once('request', (req, res) => {
 				res.end(JSON.stringify(req.headers));


### PR DESCRIPTION
Currently, HttpProxyAgent does not have a `headers` option at all. The HttpsProxyAgent does, though.

This PR adds a `headers` option, allowing consumers to set the proxy headers statically or dynamically.

Companion PR to update HttpsProxyAgent: #174
