### PR TITLE
[proxy] Ensure that `socket.remoteAddress` is a string

### DIFF
--- a/.changeset/shiny-badgers-obey.md
+++ b/.changeset/shiny-badgers-obey.md
@@ -1,0 +1,5 @@
+---
+"proxy": patch
+---
+
+Ensure that `socket.remoteAddress` is a string

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -116,12 +116,14 @@ async function onrequest(
 			// append to existing "X-Forwarded-For" header
 			// http://en.wikipedia.org/wiki/X-Forwarded-For
 			hasXForwardedFor = true;
-			value += ', ' + socket.remoteAddress;
-			debug.proxyRequest(
-				'appending to existing "%s" header: "%s"',
-				key,
-				value
-			);
+			if (typeof socket.remoteAddress === 'string') {
+				value += ', ' + socket.remoteAddress;
+				debug.proxyRequest(
+					'appending to existing "%s" header: "%s"',
+					key,
+					value
+				);
+			}
 		}
 
 		if (!hasVia && 'via' === keyLower) {
@@ -151,7 +153,7 @@ async function onrequest(
 
 	// add "X-Forwarded-For" header if it's still not here by now
 	// http://en.wikipedia.org/wiki/X-Forwarded-For
-	if (!hasXForwardedFor) {
+	if (!hasXForwardedFor && typeof socket.remoteAddress === 'string') {
 		headers['X-Forwarded-For'] = socket.remoteAddress;
 		debug.proxyRequest(
 			'adding new "X-Forwarded-For" header: "%s"',


### PR DESCRIPTION
It's possible that this value is `undefined`, so skip adding it to the `x-forwarded-for` header in that case.