### PR TITLE
Update vm2 to 3.9.18

### DIFF
--- a/.changeset/six-cheetahs-marry.md
+++ b/.changeset/six-cheetahs-marry.md
@@ -1,0 +1,5 @@
+---
+'degenerator': patch
+---
+
+Update vm2 to 3.9.18

--- a/packages/degenerator/package.json
+++ b/packages/degenerator/package.json
@@ -27,7 +27,7 @@
     "ast-types": "^0.13.2",
     "escodegen": "^1.8.1",
     "esprima": "^4.0.0",
-    "vm2": "^3.9.17"
+    "vm2": "^3.9.18"
   },
   "devDependencies": {
     "@types/escodegen": "^0.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
       vm2:
-        specifier: ^3.9.17
-        version: 3.9.17
+        specifier: ^3.9.18
+        version: 3.9.18
     devDependencies:
       '@types/escodegen':
         specifier: ^0.0.6
@@ -5169,8 +5169,8 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vm2@3.9.17:
-    resolution: {integrity: sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==}
+  /vm2@3.9.18:
+    resolution: {integrity: sha512-iM7PchOElv6Uv6Q+0Hq7dcgDtWWT6SizYqVcvol+1WQc+E9HlgTCnPozbQNSP3yDV9oXHQOEQu530w2q/BCVZg==}
     engines: {node: '>=6.0'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
This PR solves a critical security vulnerability in the vm2 package: https://www.cve.org/CVERecord?id=CVE-2023-32314