### PR TITLE
[https-proxy-agent] Slice the headers when parsing proxy server response

### DIFF
--- a/.changeset/gentle-panthers-stare.md
+++ b/.changeset/gentle-panthers-stare.md
@@ -1,0 +1,5 @@
+---
+'https-proxy-agent': patch
+---
+
+Correct the header parsing logic to stop before the response content to avoid generating an exception.

--- a/packages/https-proxy-agent/src/parse-proxy-response.ts
+++ b/packages/https-proxy-agent/src/parse-proxy-response.ts
@@ -63,7 +63,7 @@ export function parseProxyResponse(
 				return;
 			}
 
-			const headerParts = buffered.toString('ascii').split('\r\n');
+			const headerParts = buffered.slice(0,endOfHeaders).toString('ascii').split('\r\n');
 			const firstLine = headerParts.shift();
 			if (!firstLine) {
 				socket.destroy();

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -462,5 +462,5 @@ function requestAuthorization(
 		'Proxy-Authenticate': 'Basic realm="' + realm + '"',
 	};
 	res.writeHead(407, headers);
-	res.end();
+	res.end('Proxy authorization required');
 }


### PR DESCRIPTION
I have not done heavy testing, but has not broken yet.  Hopefully meets the need.