### PR TITLE
[https-proxy-agent] Support SNI as default for proxy servers

### DIFF
--- a/.changeset/four-teachers-peel.md
+++ b/.changeset/four-teachers-peel.md
@@ -1,0 +1,5 @@
+---
+"https-proxy-agent": patch
+---
+
+Support SNI for proxy servers

--- a/packages/https-proxy-agent/src/index.ts
+++ b/packages/https-proxy-agent/src/index.ts
@@ -91,7 +91,11 @@ export class HttpsProxyAgent<Uri extends string> extends Agent {
 		let socket: net.Socket;
 		if (proxy.protocol === 'https:') {
 			debug('Creating `tls.Socket`: %o', this.connectOpts);
-			socket = tls.connect(this.connectOpts);
+			const servername = this.connectOpts.servername || this.connectOpts.host;
+			socket = tls.connect({
+				...this.connectOpts,
+				servername: servername && net.isIP(servername) ? undefined : servername
+			});
 		} else {
 			debug('Creating `net.Socket`: %o', this.connectOpts);
 			socket = net.connect(this.connectOpts);


### PR DESCRIPTION
https://github.com/TooTallNate/proxy-agents/issues/14 adds a full SNI support for target servers but not proxy servers. TLS connection to proxy servers also needs SNI setting or it will raise a `Hostname/IP deosn't match` certificate error. And I think `servername` should be the proxy server host by default even the `HttpsProxyAgent` constructor can take `servername` property.
 