### PR TITLE
[socks-proxy-agent] pass `socket_options` to `SocksClient`

### DIFF
--- a/.changeset/silver-pumas-drum.md
+++ b/.changeset/silver-pumas-drum.md
@@ -1,0 +1,5 @@
+---
+"socks-proxy-agent": patch
+---
+
+[socks-proxy-agent] pass `socket_options` to `SocksClient`

--- a/packages/socks-proxy-agent/test/test.ts
+++ b/packages/socks-proxy-agent/test/test.ts
@@ -20,7 +20,6 @@ describe('SocksProxyAgent', () => {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let socksServer: any;
 	let socksServerUrl: URL;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let socksServerHost: string | null = null;
 
 	beforeEach(async () => {

--- a/packages/socks-proxy-agent/test/test.ts
+++ b/packages/socks-proxy-agent/test/test.ts
@@ -32,7 +32,7 @@ describe('SocksProxyAgent', () => {
 		await listen(socksServer, 0, socksServerHost ?? '127.0.0.1');
 		const { port, family, address } = socksServer.address();
 		socksServerUrl = new URL(
-			`socks://${family === 'IPv6' ? `localhost` : address}:${port}`
+			`socks://${family === 'IPv6' ? 'localhost' : address}:${port}`
 		);
 		socksServer.useAuth(socks.auth.None());
 	});
@@ -96,7 +96,7 @@ describe('SocksProxyAgent', () => {
 		});
 	});
 
-	describe('socket options', () => {
+	describe('ipv6 host', () => {
 		beforeAll(() => {
 			socksServerHost = '::1';
 		});
@@ -104,7 +104,7 @@ describe('SocksProxyAgent', () => {
 			socksServerHost = null;
 		});
 
-		it('should connect on ipv6 host', async () => {
+		it('should connect over ipv6 socket', async () => {
 			httpServer.once('request', function (req, res) {
 				res.end(JSON.stringify(req.headers));
 			});

--- a/packages/socks-proxy-agent/test/test.ts
+++ b/packages/socks-proxy-agent/test/test.ts
@@ -105,36 +105,25 @@ describe('SocksProxyAgent', () => {
 		});
 
 		it('should connect over ipv6 socket', async () => {
-			httpServer.once('request', function (req, res) {
-				res.end(JSON.stringify(req.headers));
-			});
+			httpServer.once('request', (req, res) => res.end());
 
 			const res = await req(new URL('/foo', httpServerUrl), {
-				agent: new SocksProxyAgent(socksServerUrl, {
-					socketOptions: { family: 6 },
-				}),
-				headers: { foo: 'bar' },
+				agent: new SocksProxyAgent(socksServerUrl, { socketOptions: { family: 6 } }),
 			});
-			const body = await json(res);
-			assert.equal('bar', body.foo);
+			assert(res);
 		});
 
 		it('should refuse connection over ipv4 socket', async () => {
 			let err: Error | undefined;
 			try {
 				await req(new URL('/foo', httpServerUrl), {
-					agent: new SocksProxyAgent(socksServerUrl, {
-						socketOptions: { family: 4 },
-					}),
+					agent: new SocksProxyAgent(socksServerUrl, { socketOptions: { family: 4 } }),
 				});
 			} catch (_err) {
 				err = _err as Error;
 			}
 			assert(err);
-			assert.equal(
-				err.message,
-				`connect ECONNREFUSED 127.0.0.1:${socksServerUrl.port}`
-			);
+			assert.equal(err.message, `connect ECONNREFUSED 127.0.0.1:${socksServerUrl.port}`);
 		});
 	});
 


### PR DESCRIPTION
This PR adds the option `socketOptions` which will get passed along to `SocksClient.createConnection` as `socket_options`.

Another solution would be to spread all the unused constructor options to the `SocksClient.createConnection` options since there are a few more that are allowed. I didn't go this route since I only have a use case for `socket_options` and I didn't want to couple the two APIs too closely. But I'd be happy to rework this PR if desired.

For reference the [`SocksClientOptions` interface](https://github.com/JoshGlazebrook/socks/blob/76d013e4c9a2d956f07868477d8f12ec0b96edfc/typings/common/constants.d.ts#L123-L131) is:

```ts
interface SocksClientOptions {
    command: SocksCommandOption;
    destination: SocksRemoteHost;
    proxy: SocksProxy;
    timeout?: number;
    existing_socket?: Duplex;
    set_tcp_nodelay?: boolean;
    socket_options?: SocketConnectOpts;
}
```