### PR TITLE
Use non-compliant URL from 'url' for socks urls

### DIFF
--- a/.changeset/eleven-bags-attend.md
+++ b/.changeset/eleven-bags-attend.md
@@ -1,0 +1,7 @@
+---
+'socks-proxy-agent': patch
+'pac-proxy-agent': patch
+'proxy-agent': patch
+---
+
+Fix Electron support by using Node.js native URL object

--- a/packages/pac-proxy-agent/src/index.ts
+++ b/packages/pac-proxy-agent/src/index.ts
@@ -5,7 +5,7 @@ import * as crypto from 'crypto';
 import { once } from 'events';
 import createDebug from 'debug';
 import { Readable } from 'stream';
-import { format } from 'url';
+import { format, URL } from 'url';
 import { Agent, AgentConnectOpts, toBuffer } from 'agent-base';
 import { HttpProxyAgent, HttpProxyAgentOptions } from 'http-proxy-agent';
 import { HttpsProxyAgent, HttpsProxyAgentOptions } from 'https-proxy-agent';

--- a/packages/proxy-agent/src/index.ts
+++ b/packages/proxy-agent/src/index.ts
@@ -1,5 +1,6 @@
 import * as http from 'http';
 import * as https from 'https';
+import { URL } from 'url';
 import LRUCache from 'lru-cache';
 import { Agent, AgentConnectOpts } from 'agent-base';
 import createDebug from 'debug';

--- a/packages/socks-proxy-agent/src/index.ts
+++ b/packages/socks-proxy-agent/src/index.ts
@@ -5,6 +5,7 @@ import * as dns from 'dns';
 import * as net from 'net';
 import * as tls from 'tls';
 import * as http from 'http';
+import { URL } from 'url';
 
 const debug = createDebug('socks-proxy-agent');
 


### PR DESCRIPTION
`new URL('socks://host:port')` gives different results in browser and Node.js because `socks` is not among the "special schemes" specified by WHATWG and thus the hostname is treated as an opaque value (without parsing the port). Node.js implementation, however, parses the `port`.

Since `proxy-agent` can be used in Electron, unless `URL` is imported directly from the Node's `url` module - it is going to use the Browser's version of it which won't work with socks urls.