### PR TITLE
Allow SOCKS proxies to be chained

### DIFF
--- a/.changeset/plenty-lamps-tease.md
+++ b/.changeset/plenty-lamps-tease.md
@@ -1,0 +1,13 @@
+---
+'socks-proxy-agent': minor
+---
+
+You can now use SOCKS proxy chains by passing an array of SOCKS proxy URLs to the `SocksProxyAgent()` constructor:
+
+```ts
+const agent = new SocksProxyAgent([
+  'socks://user:pass@host:port',
+  'socks://user:pass@host:port',
+  'socks://user:pass@host:port',
+]);
+```

--- a/packages/socks-proxy-agent/src/index.ts
+++ b/packages/socks-proxy-agent/src/index.ts
@@ -95,10 +95,13 @@ export class SocksProxyAgent extends Agent {
 	readonly shouldLookup!: boolean;
 	readonly proxies: SocksProxy[];
 	timeout: number | null;
+	rejectUnauthorized = true;
 
 	constructor(
 		uri: string | URL | string[] | URL[],
-		opts?: SocksProxyAgentOptions
+		opts?: SocksProxyAgentOptions & {
+			rejectUnauthorized?: boolean
+		}
 	) {
 		super(opts);
 
@@ -118,6 +121,7 @@ export class SocksProxyAgent extends Agent {
 		}
 
 		this.timeout = opts?.timeout ?? null;
+		this.rejectUnauthorized = opts?.rejectUnauthorized ?? true;
 	}
 
 	get proxy(): SocksProxy {
@@ -208,6 +212,7 @@ export class SocksProxyAgent extends Agent {
 			const servername = opts.servername || opts.host;
 			const tlsSocket = tls.connect({
 				...omit(opts, 'host', 'path', 'port'),
+				rejectUnauthorized: this.rejectUnauthorized,
 				socket,
 				servername: net.isIP(servername) ? undefined : servername,
 			});


### PR DESCRIPTION
Trying to use a SOCKS proxy chain with axios and there doesn't seem to currently be a straightforward way to do it.