### PR TITLE
fix: URL types were missing

### DIFF
--- a/.changeset/neat-rules-brake.md
+++ b/.changeset/neat-rules-brake.md
@@ -1,0 +1,6 @@
+---
+"http-proxy-agent": patch
+"https-proxy-agent": patch
+---
+
+Add missing `URL` type import

--- a/packages/http-proxy-agent/src/index.ts
+++ b/packages/http-proxy-agent/src/index.ts
@@ -3,8 +3,9 @@ import * as tls from 'tls';
 import * as http from 'http';
 import createDebug from 'debug';
 import { once } from 'events';
-import type { OutgoingHttpHeaders } from 'http';
 import { Agent, AgentConnectOpts } from 'agent-base';
+import { URL } from 'node:url';
+import type { OutgoingHttpHeaders } from 'http';
 
 const debug = createDebug('http-proxy-agent');
 

--- a/packages/https-proxy-agent/src/index.ts
+++ b/packages/https-proxy-agent/src/index.ts
@@ -3,9 +3,10 @@ import * as tls from 'tls';
 import * as http from 'http';
 import assert from 'assert';
 import createDebug from 'debug';
-import type { OutgoingHttpHeaders } from 'http';
 import { Agent, AgentConnectOpts } from 'agent-base';
+import { URL } from 'node:url';
 import { parseProxyResponse } from './parse-proxy-response';
+import type { OutgoingHttpHeaders } from 'http';
 
 const debug = createDebug('https-proxy-agent');
 


### PR DESCRIPTION
## PURPOSE

Fix: "URL" types were missing for below packages:
+ http-proxy-agent
+ https-proxy-agent

*Error fixed:*
![screenshot_2024_01_04_14h27-14@2x](https://github.com/TooTallNate/proxy-agents/assets/28003749/3255af5e-9838-4d39-9b5f-b645fb265fcb)
