### PR TITLE
Make decoding of base64 data URIs faster

### DIFF
--- a/.changeset/few-adults-rhyme.md
+++ b/.changeset/few-adults-rhyme.md
@@ -1,0 +1,5 @@
+---
+"data-uri-to-buffer": patch
+---
+
+Use native Buffer decoding in Node.js

--- a/packages/data-uri-to-buffer/package.json
+++ b/packages/data-uri-to-buffer/package.json
@@ -4,6 +4,10 @@
   "description": "Create an ArrayBuffer instance from a Data URI string",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    "node": "./dist/node.js",
+    "default": "./dist/index.js"
+  },
   "files": [
     "dist"
   ],

--- a/packages/data-uri-to-buffer/src/common.ts
+++ b/packages/data-uri-to-buffer/src/common.ts
@@ -1,0 +1,69 @@
+export interface ParsedDataURI {
+	type: string;
+	typeFull: string;
+	charset: string;
+	buffer: ArrayBuffer;
+}
+
+export interface IBufferConversions {
+	base64ToArrayBuffer(base64: string): ArrayBuffer;
+	stringToBuffer(str: string): ArrayBuffer;
+}
+
+/**
+ * Returns a `Buffer` instance from the given data URI `uri`.
+ *
+ * @param {String} uri Data URI to turn into a Buffer instance
+ */
+export const makeDataUriToBuffer = (convert: IBufferConversions) => (uri: string | URL): ParsedDataURI => {
+	uri = String(uri);
+
+	if (!/^data:/i.test(uri)) {
+		throw new TypeError(
+			'`uri` does not appear to be a Data URI (must begin with "data:")'
+		);
+	}
+
+	// strip newlines
+	uri = uri.replace(/\r?\n/g, '');
+
+	// split the URI up into the "metadata" and the "data" portions
+	const firstComma = uri.indexOf(',');
+	if (firstComma === -1 || firstComma <= 4) {
+		throw new TypeError('malformed data: URI');
+	}
+
+	// remove the "data:" scheme and parse the metadata
+	const meta = uri.substring(5, firstComma).split(';');
+
+	let charset = '';
+	let base64 = false;
+	const type = meta[0] || 'text/plain';
+	let typeFull = type;
+	for (let i = 1; i < meta.length; i++) {
+		if (meta[i] === 'base64') {
+			base64 = true;
+		} else if (meta[i]) {
+			typeFull += `;${meta[i]}`;
+			if (meta[i].indexOf('charset=') === 0) {
+				charset = meta[i].substring(8);
+			}
+		}
+	}
+	// defaults to US-ASCII only if type is not provided
+	if (!meta[0] && !charset.length) {
+		typeFull += ';charset=US-ASCII';
+		charset = 'US-ASCII';
+	}
+
+	// get the encoded data portion and decode URI-encoded chars
+	const data = unescape(uri.substring(firstComma + 1));
+	const buffer = base64 ? convert.base64ToArrayBuffer(data) : convert.stringToBuffer(data);
+
+	return {
+		type,
+		typeFull,
+		charset,
+		buffer,
+	};
+}

--- a/packages/data-uri-to-buffer/src/index.ts
+++ b/packages/data-uri-to-buffer/src/index.ts
@@ -5,7 +5,21 @@ export interface ParsedDataURI {
 	buffer: ArrayBuffer;
 }
 
+declare const __useCustomDecodeInTests: boolean;
+
 function base64ToArrayBuffer(base64: string) {
+	// fast path for Node.js:
+	if (typeof Buffer === 'function' && typeof __useCustomDecodeInTests === 'undefined') {
+		const nodeBuf = Buffer.from(base64, 'base64');
+		if (nodeBuf.byteLength === nodeBuf.buffer.byteLength) {
+			return nodeBuf.buffer; // large strings may get their own memory allocation
+		}
+		const buffer = new ArrayBuffer(nodeBuf.byteLength);
+		const view = new Uint8Array(buffer);
+		view.set(nodeBuf);
+		return buffer;
+	}
+
 	const chars =
 		'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 

--- a/packages/data-uri-to-buffer/src/node.ts
+++ b/packages/data-uri-to-buffer/src/node.ts
@@ -1,0 +1,28 @@
+import { makeDataUriToBuffer } from './common';
+
+export type { ParsedDataURI } from  './common';
+
+function nodeBuffertoArrayBuffer(nodeBuf: Buffer) {
+	if (nodeBuf.byteLength === nodeBuf.buffer.byteLength) {
+		return nodeBuf.buffer; // large strings may get their own memory allocation
+	}
+	const buffer = new ArrayBuffer(nodeBuf.byteLength);
+	const view = new Uint8Array(buffer);
+	view.set(nodeBuf);
+	return buffer;
+}
+
+function base64ToArrayBuffer(base64: string) {
+	return nodeBuffertoArrayBuffer(Buffer.from(base64, 'base64'));
+}
+
+function stringToBuffer(str: string): ArrayBuffer {
+	return nodeBuffertoArrayBuffer(Buffer.from(str));
+}
+
+/**
+ * Returns a `Buffer` instance from the given data URI `uri`.
+ *
+ * @param {String} uri Data URI to turn into a Buffer instance
+ */
+export const dataUriToBuffer = makeDataUriToBuffer({ stringToBuffer, base64ToArrayBuffer });

--- a/packages/data-uri-to-buffer/src/node.ts
+++ b/packages/data-uri-to-buffer/src/node.ts
@@ -17,7 +17,7 @@ function base64ToArrayBuffer(base64: string) {
 }
 
 function stringToBuffer(str: string): ArrayBuffer {
-	return nodeBuffertoArrayBuffer(Buffer.from(str));
+	return nodeBuffertoArrayBuffer(Buffer.from(str, 'ascii'));
 }
 
 /**

--- a/packages/data-uri-to-buffer/test/data-uri-to-buffer.test.ts
+++ b/packages/data-uri-to-buffer/test/data-uri-to-buffer.test.ts
@@ -1,19 +1,11 @@
 import assert from 'assert';
-import { dataUriToBuffer } from '../src';
+import { dataUriToBuffer as baseline } from '../src/index';
+import { dataUriToBuffer as node } from '../src/index';
 
-describe('data-uri-to-buffer', function () {
-	const useNativeDecodingInTest = () => {
-		delete (globalThis as Record<string, unknown>).__useCustomDecodeInTests;
-	};
+describe('node', () => doTest(node));
+describe('baseline', () => doTest(baseline));
 
-	beforeEach(() => {
-		(globalThis as Record<string, unknown>).__useCustomDecodeInTests = true;
-	});
-
-	afterEach(() => {
-		useNativeDecodingInTest();
-	});
-
+function doTest(dataUriToBuffer: typeof baseline) {
 	it('should decode bare-bones Data URIs', function () {
 		const uri = 'data:,Hello%2C%20World!';
 
@@ -25,16 +17,6 @@ describe('data-uri-to-buffer', function () {
 	});
 
 	it('should decode bare-bones "base64" Data URIs', function () {
-		const uri = 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D';
-
-		const parsed = dataUriToBuffer(uri);
-		assert.equal('text/plain', parsed.type);
-		assert.equal('Hello, World!', Buffer.from(parsed.buffer).toString());
-	});
-
-	it('should decode bare-bones "base64" Data URIs using native path', function () {
-		useNativeDecodingInTest();
-
 		const uri = 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D';
 
 		const parsed = dataUriToBuffer(uri);
@@ -209,4 +191,4 @@ describe('data-uri-to-buffer', function () {
 		assert.equal('UTF-8', parsed.charset);
 		assert.equal('abc', Buffer.from(parsed.buffer).toString());
 	});
-});
+}

--- a/packages/data-uri-to-buffer/test/data-uri-to-buffer.test.ts
+++ b/packages/data-uri-to-buffer/test/data-uri-to-buffer.test.ts
@@ -2,6 +2,18 @@ import assert from 'assert';
 import { dataUriToBuffer } from '../src';
 
 describe('data-uri-to-buffer', function () {
+	const useNativeDecodingInTest = () => {
+		delete (globalThis as Record<string, unknown>).__useCustomDecodeInTests;
+	};
+
+	beforeEach(() => {
+		(globalThis as Record<string, unknown>).__useCustomDecodeInTests = true;
+	});
+
+	afterEach(() => {
+		useNativeDecodingInTest();
+	});
+
 	it('should decode bare-bones Data URIs', function () {
 		const uri = 'data:,Hello%2C%20World!';
 
@@ -13,6 +25,16 @@ describe('data-uri-to-buffer', function () {
 	});
 
 	it('should decode bare-bones "base64" Data URIs', function () {
+		const uri = 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D';
+
+		const parsed = dataUriToBuffer(uri);
+		assert.equal('text/plain', parsed.type);
+		assert.equal('Hello, World!', Buffer.from(parsed.buffer).toString());
+	});
+
+	it('should decode bare-bones "base64" Data URIs using native path', function () {
+		useNativeDecodingInTest();
+
 		const uri = 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D';
 
 		const parsed = dataUriToBuffer(uri);

--- a/packages/data-uri-to-buffer/test/data-uri-to-buffer.test.ts
+++ b/packages/data-uri-to-buffer/test/data-uri-to-buffer.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { dataUriToBuffer as baseline } from '../src/index';
-import { dataUriToBuffer as node } from '../src/index';
+import { dataUriToBuffer as node } from '../src/node';
 
 describe('node', () => doTest(node));
 describe('baseline', () => doTest(baseline));


### PR DESCRIPTION
I saw in https://github.com/microsoft/vscode-js-debug/issues/1911 that
base64 decoding of a data URI was taking a bit of time.

This PR feature-detects the presence of a global `Buffer` to use native
decoding when running in Node.js, which is about 25x faster on a 10MB
data URI than the JS implementation in the library.

I have a bit of a hack in order to test both paths when running tests,
happy to change it if desired :)