### PR TITLE
fix: should close both connections when client disconnects

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -367,6 +367,7 @@ async function onconnect(
 			res = null;
 		}
 
+		socket.on('end', () => target.destroy());
 		socket.pipe(target);
 		target.pipe(socket);
 	}


### PR DESCRIPTION
The order was the following:

```
CONNECT spocs.getpocket.com:443 HTTP/1.1  +26ms
proxy target spocs.getpocket.com:443 "connect" event +17ms
proxy ← ← ← HTTP request spocs.getpocket.com:443 socket "end" event +541ms
proxy ← ← ← HTTP request spocs.getpocket.com:443 socket "error" event:
proxy ← ← ← Error: write EPIPE
at afterWriteDispatched (node:internal/stream_base_commons:160:15)
at writeGeneric (node:internal/stream_base_commons:151:3)
at Socket._writeGeneric (node:net:952:11)
at Socket._write (node:net:964:8)
at writeOrBuffer (node:internal/streams/writable:447:12)
at _write (node:internal/streams/writable:389:10)
at Socket.Writable.write (node:internal/streams/writable:393:10)
at Socket.ondata (node:internal/streams/readable:817:22)
at Socket.emit (node:events:514:28)
at addChunk (node:internal/streams/readable:376:12)
at readableAddChunk (node:internal/streams/readable:349:9)
at Socket.Readable.push (node:internal/streams/readable:286:10)
at TCP.onStreamRead (node:internal/stream_base_commons:190:23) +51ms
proxy ← ← ← HTTP request spocs.getpocket.com:443 socket "close" event +0ms
proxy ↓ ↓ ↓ proxy target spocs.getpocket.com:443 "end" event +57ms
proxy ↓ ↓ ↓ proxy target spocs.getpocket.com:443 "close" event +1ms
```

Before the change in the library it failed with:

```
  ● proxy › should close both connections when client disconnects

    expect(received).toEqual(expected) // deep equality

    Expected: "closed"
    Received: "writeOnly"

      225 |             ])
      226 |             expect(targetRequest.readyState).toEqual("closed")
    > 227 |             expect(serverSocket.readyState).toEqual("closed")
          |                                             ^
      228 |     });
      229 | });
      230 |

      at Object.<anonymous> (test/test.ts:227:35)
```

Fixes https://github.com/TooTallNate/proxy-agents/issues/267.
Relates https://github.com/microsoft/playwright/issues/28701.