### PR TITLE
[proxy-agent] Allow asynchronous `getProxyForUrl`

### DIFF
--- a/.changeset/nice-pillows-type.md
+++ b/.changeset/nice-pillows-type.md
@@ -2,4 +2,4 @@
 'proxy-agent': minor
 ---
 
-Allow getProxyForUrl to return a promise
+Allow `getProxyForUrl()` option to return a Promise

--- a/.changeset/nice-pillows-type.md
+++ b/.changeset/nice-pillows-type.md
@@ -1,5 +1,5 @@
 ---
-'proxy-agent': patch
+'proxy-agent': minor
 ---
 
 Allow getProxyForUrl to return a promise

--- a/.changeset/nice-pillows-type.md
+++ b/.changeset/nice-pillows-type.md
@@ -1,0 +1,5 @@
+---
+'proxy-agent': patch
+---
+
+Allow getProxyForUrl to return a promise

--- a/packages/proxy-agent/src/index.ts
+++ b/packages/proxy-agent/src/index.ts
@@ -22,7 +22,7 @@ type ValidProtocol = (typeof PROTOCOLS)[number];
 
 type AgentConstructor = new (...args: never[]) => Agent;
 
-type GetProxyForUrlCallback = (url: string) => string;
+type GetProxyForUrlCallback = (url: string) => string | Promise<string>;
 
 /**
  * Supported proxy types.
@@ -115,7 +115,7 @@ export class ProxyAgent extends Agent {
 			: 'http:';
 		const host = req.getHeader('host');
 		const url = new URL(req.path, `${protocol}//${host}`).href;
-		const proxy = this.getProxyForUrl(url);
+		const proxy = await this.getProxyForUrl(url);
 
 		if (!proxy) {
 			debug('Proxy not enabled for URL: %o', url);


### PR DESCRIPTION
This allows users to use an asynchronous `getProxyForUrl` in case they need to do asynchronous operations to resolve the correct proxy URL.  This can be the case, for example, if using `Electron.Session.resolveProxy(url)`.

Fixes #264

Test suites seem to pass; added a new one to exercise this functionality, but I can delete it if that seems like overkill.

I opted for a patch level release, because this should not affect any existing users.