### PR TITLE
Update socks dep to remove security alert

### DIFF
--- a/.changeset/happy-cups-remember.md
+++ b/.changeset/happy-cups-remember.md
@@ -1,0 +1,5 @@
+---
+'socks-proxy-agent': patch
+---
+
+Patch socks dependency to resolve ip vuln

--- a/packages/socks-proxy-agent/package.json
+++ b/packages/socks-proxy-agent/package.json
@@ -109,7 +109,7 @@
   "dependencies": {
     "agent-base": "^7.0.2",
     "debug": "^4.3.4",
-    "socks": "^2.7.1"
+    "socks": "^2.7.3"
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.5",


### PR DESCRIPTION
`npm@10.4.0` has an [indirect dependency](https://deps.dev/npm/npm/10.4.0/dependencies/graph?filter=package%3A%22ip%22+version%3A%222.0.0%22) on `ip` via `socks@2.7.1`

`ip` has a [high security vulnerability](https://deps.dev/npm/ip)

`socks@2.7.3` no longer has a dependency on `ip`, but it seems like somewhere up the chain, something is installing `2.7.1` exactly rather than going to `2.7.3`

this bump should help prevent that.