### PR TITLE
Synchronously update internal sockets length so http.Agent pooling is used

### DIFF
--- a/.changeset/seven-colts-flash.md
+++ b/.changeset/seven-colts-flash.md
@@ -1,0 +1,5 @@
+---
+"agent-base": patch
+---
+
+Synchronously update internal sockets length so `http.Agent` pooling is used

--- a/packages/agent-base/src/index.ts
+++ b/packages/agent-base/src/index.ts
@@ -124,7 +124,11 @@ export abstract class Agent extends http.Agent {
 
 	// In order to properly update the socket pool, we need to call `getName()` on
 	// the core `https.Agent` if it is a secureEndpoint.
-	private getName({ secureEndpoint, ...options }: AgentConnectOpts) {
+	getName(options: AgentConnectOpts): string {
+		const secureEndpoint =
+			typeof options.secureEndpoint === 'boolean'
+				? options.secureEndpoint
+				: this.isSecureEndpoint(options);
 		if (secureEndpoint) {
 			// @ts-expect-error `getName()` isn't defined in `@types/node`
 			return HttpsAgent.prototype.getName.call(this, options);

--- a/packages/agent-base/src/index.ts
+++ b/packages/agent-base/src/index.ts
@@ -78,12 +78,12 @@ export abstract class Agent extends http.Agent {
 	}
 
 	// In order to support async signatures in `connect()` and Node's native
-	// connection pooling in http.Agent, the array of sockets for each origin has
-	// to be updated syncronously. This is so the length of the array is accurate
+	// connection pooling in `http.Agent`, the array of sockets for each origin has
+	// to be updated synchronously. This is so the length of the array is accurate
 	// when `addRequest()` is next called. We achieve this by creating a fake socket
-	// and adding it to this.sockets and incrementing totalSocketCount.
+	// and adding it to `sockets[origin]` and incrementing `totalSocketCount`.
 	private incrementSockets(name: string) {
-		// If maxSockets and maxTotalSockets are both Infinity then there is no need
+		// If `maxSockets` and `maxTotalSockets` are both Infinity then there is no need
 		// to create a fake socket because Node.js native connection pooling will
 		// never be invoked.
 		if (this.maxSockets === Infinity && this.maxTotalSockets === Infinity) {

--- a/packages/agent-base/src/index.ts
+++ b/packages/agent-base/src/index.ts
@@ -125,11 +125,12 @@ export abstract class Agent extends http.Agent {
 	// In order to properly update the socket pool, we need to call `getName()` on
 	// the core `https.Agent` if it is a secureEndpoint.
 	private getName({ secureEndpoint, ...options }: AgentConnectOpts) {
-		return secureEndpoint
-			? // @ts-expect-error `getName()` isn't defined in `@types/node`
-			  HttpsAgent.prototype.getName.call(this, options)
-			: // @ts-expect-error `getName()` isn't defined in `@types/node`
-			  super.getName(options);
+		if (secureEndpoint) {
+			// @ts-expect-error `getName()` isn't defined in `@types/node`
+			return HttpsAgent.prototype.getName.call(this, options);
+		}
+		// @ts-expect-error `getName()` isn't defined in `@types/node`
+		return super.getName(options);
 	}
 
 	createSocket(

--- a/packages/agent-base/src/index.ts
+++ b/packages/agent-base/src/index.ts
@@ -89,15 +89,14 @@ export abstract class Agent extends http.Agent {
 		if (this.maxSockets === Infinity && this.maxTotalSockets === Infinity) {
 			return null;
 		}
+		// All instances of `sockets` are expected TypeScript errors. The alternative is to
+		// add it as a private property of this class but that will break TypeScript subclassing.
 		if (!this.sockets[name]) {
-			// All instances of `sockets` are expected TypeScript errors. The alternative is to
-			// add it as a private property of this class but that will break TypeScript subclassing.
-			// @ts-expect-error `sockets` is readonly in `@types/node` but we need to write to it
+			// @ts-expect-error `sockets` is readonly in `@types/node`
 			this.sockets[name] = [];
 		}
 		const fakeSocket = new net.Socket({ writable: false });
-		// @ts-expect-error
-		this.sockets[name].push(fakeSocket);
+		(this.sockets[name] as net.Socket[]).push(fakeSocket);
 		// @ts-expect-error `totalSocketCount` isn't defined in `@types/node`
 		this.totalSocketCount++;
 		return fakeSocket;
@@ -107,16 +106,14 @@ export abstract class Agent extends http.Agent {
 		if (!this.sockets[name] || socket === null) {
 			return;
 		}
-		// @ts-expect-error
-		const index = this.sockets[name].indexOf(socket);
+		const sockets = this.sockets[name] as net.Socket[];
+		const index = sockets.indexOf(socket);
 		if (index !== -1) {
-			// @ts-expect-error
-			this.sockets[name].splice(index, 1);
-			// @ts-expect-error
+			sockets.splice(index, 1);
+			// @ts-expect-error  `totalSocketCount` isn't defined in `@types/node`
 			this.totalSocketCount--;
-			// @ts-expect-error
-			if (this.sockets[name].length === 0) {
-				// @ts-expect-error
+			if (sockets.length === 0) {
+				// @ts-expect-error `sockets` is readonly in `@types/node`
 				delete this.sockets[name];
 			}
 		}

--- a/packages/agent-base/test/test.ts
+++ b/packages/agent-base/test/test.ts
@@ -310,6 +310,55 @@ describe('Agent (TypeScript)', () => {
 		});
 	});
 
+	it('should support `keepAlive: true` with `maxSockets`', async () => {
+		let reqCount = 0;
+		let connectCount = 0;
+
+		class MyAgent extends Agent {
+			async connect(_req: http.ClientRequest, opts: AgentConnectOpts) {
+				connectCount++;
+				assert(opts.secureEndpoint === false);
+				await sleep(10);
+				return net.connect(opts);
+			}
+		}
+		const agent = new MyAgent({ keepAlive: true, maxSockets: 1 });
+
+		const server = http.createServer(async (req, res) => {
+			expect(req.headers.connection).toEqual('keep-alive');
+			reqCount++;
+			await sleep(10);
+			res.end();
+		});
+		const addr = await listen(server);
+
+		try {
+			const resPromise = req(new URL('/foo', addr), { agent });
+			const res2Promise = req(new URL('/another', addr), { agent });
+
+			const res = await resPromise;
+			expect(reqCount).toEqual(1);
+			expect(connectCount).toEqual(1);
+			expect(res.headers.connection).toEqual('keep-alive');
+
+			res.resume();
+			const s1 = res.socket;
+			await once(s1, 'free');
+
+			const res2 = await res2Promise;
+			expect(reqCount).toEqual(2);
+			expect(connectCount).toEqual(1);
+			expect(res2.headers.connection).toEqual('keep-alive');
+			assert(res2.socket === s1);
+
+			res2.resume();
+			await once(res2.socket, 'free');
+		} finally {
+			agent.destroy();
+			server.close();
+		}
+	});
+
 	describe('"https" module', () => {
 		it('should work for basic HTTPS requests', async () => {
 			let gotReq = false;

--- a/packages/agent-base/test/test.ts
+++ b/packages/agent-base/test/test.ts
@@ -79,6 +79,7 @@ describe('Agent (TypeScript)', () => {
 				) {
 					gotCallback = true;
 					assert(opts.secureEndpoint === false);
+					assert.equal(this.getName(opts), `127.0.0.1:${port}:`);
 					return net.connect(opts);
 				}
 			}
@@ -308,55 +309,60 @@ describe('Agent (TypeScript)', () => {
 				server2.close();
 			}
 		});
-	});
 
-	it('should support `keepAlive: true` with `maxSockets`', async () => {
-		let reqCount = 0;
-		let connectCount = 0;
+		it('should support `keepAlive: true` with `maxSockets`', async () => {
+			let reqCount = 0;
+			let connectCount = 0;
 
-		class MyAgent extends Agent {
-			async connect(_req: http.ClientRequest, opts: AgentConnectOpts) {
-				connectCount++;
-				assert(opts.secureEndpoint === false);
-				await sleep(10);
-				return net.connect(opts);
+			class MyAgent extends Agent {
+				async connect(
+					_req: http.ClientRequest,
+					opts: AgentConnectOpts
+				) {
+					connectCount++;
+					assert(opts.secureEndpoint === false);
+					await sleep(10);
+					return net.connect(opts);
+				}
 			}
-		}
-		const agent = new MyAgent({ keepAlive: true, maxSockets: 1 });
+			const agent = new MyAgent({ keepAlive: true, maxSockets: 1 });
 
-		const server = http.createServer(async (req, res) => {
-			expect(req.headers.connection).toEqual('keep-alive');
-			reqCount++;
-			await sleep(10);
-			res.end();
+			const server = http.createServer(async (req, res) => {
+				expect(req.headers.connection).toEqual('keep-alive');
+				reqCount++;
+				await sleep(10);
+				res.end();
+			});
+			const addr = await listen(server);
+
+			try {
+				const resPromise = req(new URL('/foo', addr), { agent });
+				const res2Promise = req(new URL('/another', addr), {
+					agent,
+				});
+
+				const res = await resPromise;
+				expect(reqCount).toEqual(1);
+				expect(connectCount).toEqual(1);
+				expect(res.headers.connection).toEqual('keep-alive');
+
+				res.resume();
+				const s1 = res.socket;
+				await once(s1, 'free');
+
+				const res2 = await res2Promise;
+				expect(reqCount).toEqual(2);
+				expect(connectCount).toEqual(1);
+				expect(res2.headers.connection).toEqual('keep-alive');
+				assert(res2.socket === s1);
+
+				res2.resume();
+				await once(res2.socket, 'free');
+			} finally {
+				agent.destroy();
+				server.close();
+			}
 		});
-		const addr = await listen(server);
-
-		try {
-			const resPromise = req(new URL('/foo', addr), { agent });
-			const res2Promise = req(new URL('/another', addr), { agent });
-
-			const res = await resPromise;
-			expect(reqCount).toEqual(1);
-			expect(connectCount).toEqual(1);
-			expect(res.headers.connection).toEqual('keep-alive');
-
-			res.resume();
-			const s1 = res.socket;
-			await once(s1, 'free');
-
-			const res2 = await res2Promise;
-			expect(reqCount).toEqual(2);
-			expect(connectCount).toEqual(1);
-			expect(res2.headers.connection).toEqual('keep-alive');
-			assert(res2.socket === s1);
-
-			res2.resume();
-			await once(res2.socket, 'free');
-		} finally {
-			agent.destroy();
-			server.close();
-		}
 	});
 
 	describe('"https" module', () => {
@@ -371,6 +377,10 @@ describe('Agent (TypeScript)', () => {
 				): net.Socket {
 					gotCallback = true;
 					assert(opts.secureEndpoint === true);
+					assert.equal(
+						this.getName(opts),
+						`127.0.0.1:${port}::::::::false:::::::::::::`
+					);
 					return tls.connect(opts);
 				}
 			}

--- a/packages/agent-base/test/test.ts
+++ b/packages/agent-base/test/test.ts
@@ -568,5 +568,63 @@ describe('Agent (TypeScript)', () => {
 				server.close();
 			}
 		});
+
+		it('should support `keepAlive: true` with `maxSockets`', async () => {
+			let reqCount = 0;
+			let connectCount = 0;
+
+			class MyAgent extends Agent {
+				async connect(
+					_req: http.ClientRequest,
+					opts: AgentConnectOpts
+				) {
+					connectCount++;
+					assert(opts.secureEndpoint === true);
+					await sleep(10);
+					return tls.connect(opts);
+				}
+			}
+			const agent = new MyAgent({ keepAlive: true, maxSockets: 1 });
+
+			const server = https.createServer(sslOptions, async (req, res) => {
+				expect(req.headers.connection).toEqual('keep-alive');
+				reqCount++;
+				await sleep(10);
+				res.end();
+			});
+			const addr = await listen(server);
+
+			try {
+				const resPromise = req(new URL('/foo', addr), {
+					agent,
+					rejectUnauthorized: false,
+				});
+				const res2Promise = req(new URL('/another', addr), {
+					agent,
+					rejectUnauthorized: false,
+				});
+
+				const res = await resPromise;
+				expect(reqCount).toEqual(1);
+				expect(connectCount).toEqual(1);
+				expect(res.headers.connection).toEqual('keep-alive');
+
+				res.resume();
+				const s1 = res.socket;
+				await once(s1, 'free');
+
+				const res2 = await res2Promise;
+				expect(reqCount).toEqual(2);
+				expect(connectCount).toEqual(1);
+				expect(res2.headers.connection).toEqual('keep-alive');
+				assert(res2.socket === s1);
+
+				res2.resume();
+				await once(res2.socket, 'free');
+			} finally {
+				agent.destroy();
+				server.close();
+			}
+		});
 	});
 });


### PR DESCRIPTION
Fixes #299

This is a bit of a hack, but I went with this approach because it allows for all of the native socket pooling behavior in `http.Agent` to be used and `connect()` to keep it's async signature.

The tradeoff is manipulating the internal `sockets` dictionary which is `readonly` (according to `@types/node`) and therefore needs a lot of `@ts-expect-error` comments. An alternative approach would require overwriting the `addRequest()` method with custom pooling code.

The approach in this PR works by synchronously adding a fake socket to the pool so `this.sockets[originName].length` is accurate before any other requests are added. Then the socket is removed directly after `connect()` finishes.