### PR TITLE
Bump lru-cache and provide `dispose()` method

### DIFF
--- a/.changeset/unlucky-vans-shout.md
+++ b/.changeset/unlucky-vans-shout.md
@@ -1,0 +1,5 @@
+---
+'proxy-agent': patch
+---
+
+Bump lru-cache dependency and dispose of Agent instances in cache correctly

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -36,7 +36,7 @@
     "debug": "^4.3.4",
     "http-proxy-agent": "^7.0.1",
     "https-proxy-agent": "^7.0.5",
-    "lru-cache": "^7.14.1",
+    "lru-cache": "^11.0.0",
     "pac-proxy-agent": "^7.0.2",
     "proxy-from-env": "^1.1.0",
     "socks-proxy-agent": "^8.0.4"

--- a/packages/proxy-agent/src/index.ts
+++ b/packages/proxy-agent/src/index.ts
@@ -1,7 +1,7 @@
 import * as http from 'http';
 import * as https from 'https';
 import { URL } from 'url';
-import LRUCache from 'lru-cache';
+import { LRUCache } from 'lru-cache';
 import { Agent, AgentConnectOpts } from 'agent-base';
 import createDebug from 'debug';
 import { getProxyForUrl as envGetProxyForUrl } from 'proxy-from-env';
@@ -83,7 +83,7 @@ export class ProxyAgent extends Agent {
 	/**
 	 * Cache for `Agent` instances.
 	 */
-	cache = new LRUCache<string, Agent>({ max: 20 });
+	cache = new LRUCache<string, Agent>({ max: 20, dispose: agent => agent.destroy() });
 
 	connectOpts?: ProxyAgentOptions;
 	httpAgent: http.Agent;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,8 +409,8 @@ importers:
         specifier: ^7.0.5
         version: link:../https-proxy-agent
       lru-cache:
-        specifier: ^7.14.1
-        version: 7.14.1
+        specifier: ^11.0.0
+        version: 11.0.0
       pac-proxy-agent:
         specifier: ^7.0.2
         version: link:../pac-proxy-agent
@@ -4412,6 +4412,11 @@ packages:
     engines: {node: 14 || >=16.14}
     dev: true
 
+  /lru-cache@11.0.0:
+    resolution: {integrity: sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==}
+    engines: {node: 20 || >=22}
+    dev: false
+
   /lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
     dependencies:
@@ -4431,11 +4436,6 @@ packages:
     dependencies:
       yallist: 4.0.0
     dev: true
-
-  /lru-cache@7.14.1:
-    resolution: {integrity: sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==}
-    engines: {node: '>=12'}
-    dev: false
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}


### PR DESCRIPTION
Bumping the dependency is just a drive-by; this is mostly for making sure that `Agent` instances in the cache are destroyed when no longer reachable.