### PR TITLE
Pass `req` to `getProxyForUrl` callback

### DIFF
--- a/.changeset/sixty-carpets-cross.md
+++ b/.changeset/sixty-carpets-cross.md
@@ -1,0 +1,5 @@
+---
+'proxy-agent': minor
+---
+
+Include ClientRequest in getProxyForUrl parameters for additional flexibility

--- a/packages/proxy-agent/src/index.ts
+++ b/packages/proxy-agent/src/index.ts
@@ -22,7 +22,7 @@ type ValidProtocol = (typeof PROTOCOLS)[number];
 
 type AgentConstructor = new (...args: never[]) => Agent;
 
-type GetProxyForUrlCallback = (url: string) => string | Promise<string>;
+type GetProxyForUrlCallback = (url: string, req: http.ClientRequest) => string | Promise<string>;
 
 /**
  * Supported proxy types.
@@ -69,7 +69,7 @@ export type ProxyAgentOptions = HttpProxyAgentOptions<''> &
 		 * Defaults to standard proxy environment variables,
 		 * see https://www.npmjs.com/package/proxy-from-env for details
 		 */
-		getProxyForUrl?: GetProxyForUrlCallback;
+		getProxyForUrl: GetProxyForUrlCallback;
 	};
 
 /**
@@ -90,7 +90,7 @@ export class ProxyAgent extends Agent {
 	httpsAgent: http.Agent;
 	getProxyForUrl: GetProxyForUrlCallback;
 
-	constructor(opts?: ProxyAgentOptions) {
+	constructor(opts: ProxyAgentOptions) {
 		super(opts);
 		debug('Creating new ProxyAgent instance: %o', opts);
 		this.connectOpts = opts;
@@ -115,7 +115,7 @@ export class ProxyAgent extends Agent {
 			: 'http:';
 		const host = req.getHeader('host');
 		const url = new URL(req.path, `${protocol}//${host}`).href;
-		const proxy = await this.getProxyForUrl(url);
+		const proxy = await this.getProxyForUrl(url, req);
 
 		if (!proxy) {
 			debug('Proxy not enabled for URL: %o', url);

--- a/packages/proxy-agent/test/test.ts
+++ b/packages/proxy-agent/test/test.ts
@@ -266,15 +266,17 @@ describe('ProxyAgent', () => {
 		it('should call provided function with getProxyForUrl option', async () => {
 			let gotCall = false;
 			let urlParameter = '';
+			let reqParameter: http.ClientRequest | undefined;
 			httpsServer.once('request', function (req, res) {
 				res.end(JSON.stringify(req.headers));
 			});
 
 			const agent = new ProxyAgent({
 				rejectUnauthorized: false,
-				getProxyForUrl: (u) => {
+				getProxyForUrl: (u, r) => {
 					gotCall = true;
 					urlParameter = u;
+					reqParameter = r;
 					return httpsProxyServerUrl.href;
 				},
 			});
@@ -287,6 +289,7 @@ describe('ProxyAgent', () => {
 			assert(httpsServerUrl.host === body.host);
 			assert(gotCall);
 			assert(requestUrl.href === urlParameter);
+			assert(reqParameter?.constructor.name === 'ClientRequest');
 		});
 
 		it('should call provided function with asynchronous getProxyForUrl option', async () => {


### PR DESCRIPTION
This allows more flexibility in the callback, e.g. for inspecting request headers before deciding on a given proxy.