### PR TITLE
support tls fingerprint args in constructor

### DIFF
--- a/packages/https-proxy-agent/src/index.ts
+++ b/packages/https-proxy-agent/src/index.ts
@@ -50,7 +50,7 @@ export class HttpsProxyAgent<Uri extends string> extends Agent {
 
 	constructor(proxy: Uri | URL, opts?: HttpsProxyAgentOptions<Uri>) {
 		super(opts);
-		this.options = { path: undefined };
+		this.options = { path: undefined, ...opts };
 		this.proxy = typeof proxy === 'string' ? new URL(proxy) : proxy;
 		this.proxyHeaders = opts?.headers ?? {};
 		debug('Creating new HttpsProxyAgent instance: %o', this.proxy.href);


### PR DESCRIPTION
hey nate! first off big thanks for this package. it has been incredibly valuable for project.

I'm wanting to include the tls ciphers list (and other, similar params) on the agent constructor:
```
new HttpsProxyAgent('http://user:pass@$example.com:1234' {
  rejectUnauthorized: false,
  ciphers: [
    'ECDHE-ECDSA-AES128-GCM-SHA256',
    'ECDHE-RSA-AES128-GCM-SHA256',
    'ECDHE-ECDSA-AES256-GCM-SHA384',
    'ECDHE-RSA-AES256-GCM-SHA384',
    'DHE-RSA-AES128-GCM-SHA256',
    'DHE-RSA-AES256-GCM-SHA384'
    ].join(':'),
    honorCipherOrder: true,
    secureProtocol: 'TLSv1_2_method',
})
```
(Btw, i am making `GET`s to `https://check.ja3.zone/` to check if the fingerprint is changing, e.g. the `ciphers` declaration is effective)

I found that the `ciphers`, `honorCipherOrder`, `secureProtocol` params don't make it to the base `http.Agent` object, which is needed to have the effect I'm looking for.  And, including the constructor `opts` in the `this.options` seems to do the trick.

I'll be honest, I don't deeply understand this code. I just know that this code diff has the affect i desire.  Perhaps there are keys that should/should not be here???? Perhaps you want a blacklist or whitelist strategy? I see you have the `omit` function to remove things.  I don't have a strong preference on this stuff, I just want `ciphers`, `honorCipherOrder`, `secureProtocol` (and `secureOptions`) to be included in `this.options`.

Thanks again! I hope this is helpful.

