### PR TITLE
Handle exceptions from agent addRequest()

### DIFF
--- a/.changeset/pretty-terms-exercise.md
+++ b/.changeset/pretty-terms-exercise.md
@@ -1,0 +1,5 @@
+---
+'agent-base': patch
+---
+
+Handle exceptions caused by Agent.addRequest()

--- a/packages/agent-base/src/index.ts
+++ b/packages/agent-base/src/index.ts
@@ -154,8 +154,12 @@ export abstract class Agent extends http.Agent {
 				(socket) => {
 					this.decrementSockets(name, fakeSocket);
 					if (socket instanceof http.Agent) {
-						// @ts-expect-error `addRequest()` isn't defined in `@types/node`
-						return socket.addRequest(req, connectOpts);
+						try {
+							// @ts-expect-error `addRequest()` isn't defined in `@types/node`
+							return socket.addRequest(req, connectOpts);
+						} catch (err: unknown) {
+							return cb(err as Error);
+						}
 					}
 					this[INTERNAL].currentSocket = socket;
 					// @ts-expect-error `createSocket()` isn't defined in `@types/node`


### PR DESCRIPTION
`tls.createSecureContext()` can throw exceptions, so `.addRequest()` can throw exceptions as well.