### PR TITLE
Revert "Remove `net.isIP()` check for TLS `servername` (#312)"

### DIFF
--- a/packages/https-proxy-agent/src/index.ts
+++ b/packages/https-proxy-agent/src/index.ts
@@ -96,7 +96,8 @@ export class HttpsProxyAgent<Uri extends string> extends Agent {
 				this.connectOpts.servername || this.connectOpts.host;
 			socket = tls.connect({
 				...this.connectOpts,
-				servername,
+				servername:
+					servername && net.isIP(servername) ? undefined : servername,
 			});
 		} else {
 			debug('Creating `net.Socket`: %o', this.connectOpts);
@@ -150,7 +151,7 @@ export class HttpsProxyAgent<Uri extends string> extends Agent {
 				return tls.connect({
 					...omit(opts, 'host', 'path', 'port'),
 					socket,
-					servername,
+					servername: net.isIP(servername) ? undefined : servername,
 				});
 			}
 

--- a/packages/pac-proxy-agent/src/index.ts
+++ b/packages/pac-proxy-agent/src/index.ts
@@ -240,7 +240,10 @@ export class PacProxyAgent<Uri extends string> extends Agent {
 					const servername = opts.servername || opts.host;
 					socket = tls.connect({
 						...opts,
-						servername,
+						servername:
+							!servername || net.isIP(servername)
+								? undefined
+								: servername,
 					});
 				} else {
 					socket = net.connect(opts);

--- a/packages/socks-proxy-agent/src/index.ts
+++ b/packages/socks-proxy-agent/src/index.ts
@@ -175,7 +175,7 @@ export class SocksProxyAgent extends Agent {
 			const tlsSocket = tls.connect({
 				...omit(opts, 'host', 'path', 'port'),
 				socket,
-				servername,
+				servername: net.isIP(servername) ? undefined : servername,
 			});
 
 			tlsSocket.once('error', (error) => {


### PR DESCRIPTION
Currently when running e.g. the https-proxy-agent tests, it results in:

```
(node:24804) [DEP0123] DeprecationWarning: Setting the TLS ServerName to an IP address is not permitted by RFC 6066. This will be ignored in a future version.
    at Object.connect (node:_tls_wrap:1812:15)
    at HttpsProxyAgent.connect (/Users/maxschmitt/Developer/tmp/proxy-agents/packages/https-proxy-agent/src/index.ts:97:17)
    at /Users/maxschmitt/Developer/tmp/proxy-agents/packages/agent-base/src/index.ts:152:21
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
```

TLS servername does not allow IPs, as per:

- https://datatracker.ietf.org/doc/html/rfc6066#section-3:~:text=Literal%20IPv4%20and%20IPv6%20addresses%20are%20not%20permitted%20in%20%22HostName%22.
- https://nodejs.org/api/deprecations.html#DEP0123

It looks like the scenario in https://github.com/TooTallNate/proxy-agents/issues/308 is not supported by Node.js nor TLS spec, hence I recommend adding the check back.

We at Playwright run tests against 127.0.0.1 and also end up in this warning.

This reverts commit 5908e84db988a3ab7316fec848b7cd00b64ec94e.