### PR TITLE
Pass req to getProxyForUrl callback

### DIFF
--- a/.changeset/sixty-carpets-cross.md
+++ b/.changeset/sixty-carpets-cross.md
@@ -1,0 +1,5 @@
+---
+'proxy-agent': minor
+---
+
+Include ClientRequest in getProxyForUrl parameters for additional flexibility

--- a/packages/proxy-agent/src/index.ts
+++ b/packages/proxy-agent/src/index.ts
@@ -72,7 +72,7 @@ export type ProxyAgentOptions = HttpProxyAgentOptions<''> &
 		 * Defaults to standard proxy environment variables,
 		 * see https://www.npmjs.com/package/proxy-from-env for details
 		 */
-		getProxyForUrl: GetProxyForUrlCallback;
+		getProxyForUrl?: GetProxyForUrlCallback;
 	};
 
 /**
@@ -93,7 +93,7 @@ export class ProxyAgent extends Agent {
 	httpsAgent: http.Agent;
 	getProxyForUrl: GetProxyForUrlCallback;
 
-	constructor(opts: ProxyAgentOptions) {
+	constructor(opts?: ProxyAgentOptions) {
 		super(opts);
 		debug('Creating new ProxyAgent instance: %o', opts);
 		this.connectOpts = opts;

--- a/packages/proxy-agent/src/index.ts
+++ b/packages/proxy-agent/src/index.ts
@@ -22,7 +22,10 @@ type ValidProtocol = (typeof PROTOCOLS)[number];
 
 type AgentConstructor = new (...args: never[]) => Agent;
 
-type GetProxyForUrlCallback = (url: string) => string | Promise<string>;
+type GetProxyForUrlCallback = (
+	url: string,
+	req: http.ClientRequest
+) => string | Promise<string>;
 
 /**
  * Supported proxy types.
@@ -69,7 +72,7 @@ export type ProxyAgentOptions = HttpProxyAgentOptions<''> &
 		 * Defaults to standard proxy environment variables,
 		 * see https://www.npmjs.com/package/proxy-from-env for details
 		 */
-		getProxyForUrl?: GetProxyForUrlCallback;
+		getProxyForUrl: GetProxyForUrlCallback;
 	};
 
 /**
@@ -90,7 +93,7 @@ export class ProxyAgent extends Agent {
 	httpsAgent: http.Agent;
 	getProxyForUrl: GetProxyForUrlCallback;
 
-	constructor(opts?: ProxyAgentOptions) {
+	constructor(opts: ProxyAgentOptions) {
 		super(opts);
 		debug('Creating new ProxyAgent instance: %o', opts);
 		this.connectOpts = opts;
@@ -115,7 +118,7 @@ export class ProxyAgent extends Agent {
 			: 'http:';
 		const host = req.getHeader('host');
 		const url = new URL(req.path, `${protocol}//${host}`).href;
-		const proxy = await this.getProxyForUrl(url);
+		const proxy = await this.getProxyForUrl(url, req);
 
 		if (!proxy) {
 			debug('Proxy not enabled for URL: %o', url);

--- a/packages/proxy-agent/test/test.ts
+++ b/packages/proxy-agent/test/test.ts
@@ -266,15 +266,17 @@ describe('ProxyAgent', () => {
 		it('should call provided function with getProxyForUrl option', async () => {
 			let gotCall = false;
 			let urlParameter = '';
+			let reqParameter: http.ClientRequest | undefined;
 			httpsServer.once('request', function (req, res) {
 				res.end(JSON.stringify(req.headers));
 			});
 
 			const agent = new ProxyAgent({
 				rejectUnauthorized: false,
-				getProxyForUrl: (u) => {
+				getProxyForUrl: (u, r) => {
 					gotCall = true;
 					urlParameter = u;
+					reqParameter = r;
 					return httpsProxyServerUrl.href;
 				},
 			});
@@ -287,6 +289,7 @@ describe('ProxyAgent', () => {
 			assert(httpsServerUrl.host === body.host);
 			assert(gotCall);
 			assert(requestUrl.href === urlParameter);
+			assert(reqParameter?.constructor.name === 'ClientRequest');
 		});
 
 		it('should call provided function with asynchronous getProxyForUrl option', async () => {
@@ -298,7 +301,7 @@ describe('ProxyAgent', () => {
 
 			const agent = new ProxyAgent({
 				rejectUnauthorized: false,
-				getProxyForUrl: async(u) => {
+				getProxyForUrl: async (u) => {
 					gotCall = true;
 					urlParameter = u;
 					await promisify(setTimeout)(1);


### PR DESCRIPTION
Same as #326 with one minor change in 869ecbc36cdb363bae4b5cbae66cf68c09fe3488 to keep the optionality of the constructor and getProxyForUrl arguments to keep TypeScript happy.

Closes #326.