### PR TITLE
Only overwrite servername in tls connect when host is not an IP address

### DIFF
--- a/.changeset/lovely-boxes-heal.md
+++ b/.changeset/lovely-boxes-heal.md
@@ -1,0 +1,7 @@
+---
+"https-proxy-agent": patch
+"pac-proxy-agent": patch
+"socks-proxy-agent": patch
+---
+
+Only overwrite servername in tls connect when host is not an IP address

--- a/packages/pac-proxy-agent/src/index.ts
+++ b/packages/pac-proxy-agent/src/index.ts
@@ -24,6 +24,23 @@ import { getQuickJS } from '@tootallnate/quickjs-emscripten';
 
 const debug = createDebug('pac-proxy-agent');
 
+const setServernameFromNonIpHost = <
+	T extends { host?: string; servername?: string }
+>(
+	options: T
+) => {
+	if (
+		options.servername === undefined &&
+		options.host &&
+		!net.isIP(options.host)
+	) {
+		return {
+			...options,
+			servername: options.host,
+		};
+	}
+	return options;
+};
 type Protocols = keyof typeof gProtocols;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -238,11 +255,7 @@ export class PacProxyAgent<Uri extends string> extends Agent {
 			if (type === 'DIRECT') {
 				// Direct connection to the destination endpoint
 				if (secureEndpoint) {
-					const servername = opts.servername || opts.host;
-					socket = tls.connect({
-						...opts,
-						servername,
-					});
+					socket = tls.connect(setServernameFromNonIpHost(opts));
 				} else {
 					socket = net.connect(opts);
 				}


### PR DESCRIPTION
This is an alternative to #337 (which was created to revert #312).

Based on the original report in #308, I think reverting is not ideal since it would (re-)break the use case described where Kubernetes issues certificates for hosts that area reachable by IP. (Kubernetes is not an area I have much experience in so this is reiterating the original report but I have not tested this.)

But I do think the end result of #337 is nice in that it removes the warning for a common use case. Regardless of Node showing a deprecation warning and RFC 6066, it would be nice not to show the warning since even the tests in this repo trigger the deprecation message.

I searched a bit and found an example of `node-postres` handling this same issue with a solution that accounts for both situations: https://github.com/brianc/node-postgres/pull/1890

This PR copies that code into a helper function used in all places that `net.isIP` was used.

Closes #337.