### PR TITLE
[pac-proxy-agent] Expose `PacProxyAgent.getResolver()` publicly

### DIFF
--- a/.changeset/popular-toys-happen.md
+++ b/.changeset/popular-toys-happen.md
@@ -1,0 +1,5 @@
+---
+"pac-proxy-agent": minor
+---
+
+Expose `PacProxyAgent.getResolver()` publicly

--- a/packages/pac-proxy-agent/src/index.ts
+++ b/packages/pac-proxy-agent/src/index.ts
@@ -118,10 +118,8 @@ export class PacProxyAgent<Uri extends string> extends Agent {
 	/**
 	 * Loads the PAC proxy file from the source if necessary, and returns
 	 * a generated `FindProxyForURL()` resolver function to use.
-	 *
-	 * @api private
 	 */
-	private getResolver(): Promise<FindProxyForURL> {
+	getResolver(): Promise<FindProxyForURL> {
 		if (!this.resolverPromise) {
 			this.resolverPromise = this.loadResolver();
 			this.resolverPromise.then(

--- a/packages/pac-proxy-agent/test/test.ts
+++ b/packages/pac-proxy-agent/test/test.ts
@@ -130,6 +130,21 @@ describe('PacProxyAgent', () => {
 		});
 	});
 
+	describe('getResolver', () => {
+		it('should allow lookups without connecting', async () => {
+			function FindProxyForURL() {
+				return 'PROXY http-proxy.example.org:443;';
+			}
+
+			const uri = `data:,${encodeURIComponent(FindProxyForURL.toString())}`;
+			const agent = new PacProxyAgent(uri);
+
+			const resolver = await agent.getResolver();
+			const proxy = await resolver("https://example.com/test")
+			assert.equal(proxy, "PROXY http-proxy.example.org:443;")
+		});
+	})
+
 	describe('"http" module', () => {
 		it('should work over an HTTP proxy', async () => {
 			httpServer.once('request', function (req, res) {


### PR DESCRIPTION
This enables calling code to determine the proxy that will be used for a remote host without actually initiating a connection to it.

Fixes #362