### PR TITLE
fix: do not ignore host when connect tls

### DIFF
--- a/packages/socks-proxy-agent/src/index.ts
+++ b/packages/socks-proxy-agent/src/index.ts
@@ -189,12 +189,7 @@ export class SocksProxyAgent extends Agent {
 			// this socket connection to a TLS connection.
 			debug('Upgrading socket connection to TLS');
 			const tlsSocket = tls.connect({
-				...omit(
-					setServernameFromNonIpHost(opts),
-					'host',
-					'path',
-					'port'
-				),
+				...omit(setServernameFromNonIpHost(opts), 'path', 'port'),
 				socket,
 			});
 


### PR DESCRIPTION
for bilateral tls verification, the `host` should not be ignored, if the `host` field be ignored, it will be set to `localhost` automatically. But the default host(`localhost`) is not correspoding to tls certificate.

for kubernetes it will use bilateral tls verification, for tls website it will use single tls verification. And I've already tested the traditional tls web site and the communication of kuberntes apiserver two traditional cases, it all works ok.

relasted issues: #365 