### PR TITLE
brl-1 Need to close the handle when there is a cache hit

### DIFF
--- a/packages/get-uri/src/file.ts
+++ b/packages/get-uri/src/file.ts
@@ -50,6 +50,7 @@ export const file: GetUriProtocol<FileOptions> = async (
 
 		// if a `cache` was provided, check if the file has not been modified
 		if (cache && cache.stat && stat && isNotModified(cache.stat, stat)) {
+			await fdHandle.close();
 			throw new NotModifiedError();
 		}
 


### PR DESCRIPTION
We found that the `pac-proxy-agent` was leaking file descriptors via `getUri` for file based `pac.js` whenever there is a cache hit. This PR includes the fix we use to avoid the leak.