### PR TITLE
Fixing TS2322 / getName

### DIFF
--- a/packages/agent-base/src/index.ts
+++ b/packages/agent-base/src/index.ts
@@ -124,7 +124,7 @@ export abstract class Agent extends http.Agent {
 
 	// In order to properly update the socket pool, we need to call `getName()` on
 	// the core `https.Agent` if it is a secureEndpoint.
-	getName(options: AgentConnectOpts): string {
+	getName(options: AgentGetNameOptions): string {
 		const secureEndpoint =
 			typeof options.secureEndpoint === 'boolean'
 				? options.secureEndpoint


### PR DESCRIPTION
```
error TS2322: [...]
    Types of property 'getName' are incompatible.
      Type '(options: AgentConnectOpts) => string' is not assignable to type '(options?: AgentGetNameOptions | undefined) => string'.
[...]
```