### PR TITLE
Make options for `Agent.prototype.getName` optional

### DIFF
--- a/.changeset/short-spiders-travel.md
+++ b/.changeset/short-spiders-travel.md
@@ -1,0 +1,5 @@
+---
+'agent-base': patch
+---
+
+Fix compatibility with `@types/node@20.19.2`.

--- a/packages/agent-base/src/index.ts
+++ b/packages/agent-base/src/index.ts
@@ -124,11 +124,8 @@ export abstract class Agent extends http.Agent {
 
 	// In order to properly update the socket pool, we need to call `getName()` on
 	// the core `https.Agent` if it is a secureEndpoint.
-	getName(options: AgentConnectOpts): string {
-		const secureEndpoint =
-			typeof options.secureEndpoint === 'boolean'
-				? options.secureEndpoint
-				: this.isSecureEndpoint(options);
+	getName(options?: AgentConnectOpts): string {
+		const secureEndpoint = this.isSecureEndpoint(options);
 		if (secureEndpoint) {
 			// @ts-expect-error `getName()` isn't defined in `@types/node`
 			return HttpsAgent.prototype.getName.call(this, options);


### PR DESCRIPTION
In `@types/node@20.19.2`, `getName` was added (https://github.com/DefinitelyTyped/DefinitelyTyped/commit/239534ac5225c56966e7df1b83aeba21a29f6349) with an optional argument, meaning `Agent` is not assignable to the `@types/node` declaration. This makes the `options` object optional and removes the unnecessary `options.secureEndpoint` check since `this.isSecureEndpoint` already handles it.

From history of [`Agent.prototype.getName` in Node documentation](https://nodejs.org/api/http.html#agentgetnameoptions):

> v17.7.0, v16.15.0 | The options parameter is now optional.

Based on that line, I think the `@types/node` interpretation is accurate and this `Agent` implementation should assume the parameter may not be provided.

I do see several explicit `any` and `@ts-expect-error` related to the fact that `getName` was not included in `@types/node`. Now that it is, it might be worth bumping this depending and resolving those typing issues, but that seems more involved so I decided to keep this PR narrowly scoped for now.

I'm not 100% there aren't any more typing errors, but this is the only one [I encountered](https://github.com/angular/angular-cli/actions/runs/15966211508/job/45027055192?pr=30625) when bumping `@types/node`.