### PR TITLE
fix(http-proxy-agent): add support for raw header format

### DIFF
--- a/packages/http-proxy-agent/src/index.ts
+++ b/packages/http-proxy-agent/src/index.ts
@@ -83,7 +83,18 @@ export class HttpProxyAgent<Uri extends string> extends Agent {
 	): void {
 		const { proxy } = this;
 		const protocol = opts.secureEndpoint ? 'https:' : 'http:';
-		const hostname = req.getHeader('host') || 'localhost';
+
+		let hostname = req.getHeader('host');
+		// If host header is not set or available in the processed headers, construct it from opts.host and opts.port
+		if (!hostname) {
+			const host = opts.host || 'localhost';
+			const port = opts.port || '';
+			
+			// Wrap IPv6 addresses in brackets for proper hostname format
+			const formattedHost = net.isIPv6(host) ? `[${host}]` : host;
+			hostname = port ? `${formattedHost}:${port}` : formattedHost;
+		}
+
 		const base = `${protocol}//${hostname}`;
 		const url = new URL(req.path, base);
 		if (opts.port !== 80) {


### PR DESCRIPTION
`https-proxy-agent` supports the NodeJS raw header format but `http-proxy-agent` and `pac-proxy-agent` don't. Created from issue: #382.

Link to `https-proxy-agent` [code](https://github.com/TooTallNate/proxy-agents/blob/b923f5363875d8fd56477094d5ffc562840a4b76/packages/https-proxy-agent/src/index.ts#L123) which doesn't use `req.getHeader()` like `http-proxy-agent`. Which is what causes the issue with raw headers