### PR TITLE
feat(http-proxy-agent): emit 'proxyConnect' event

### DIFF
--- a/.changeset/http-proxy-agent-proxyconnect.md
+++ b/.changeset/http-proxy-agent-proxyconnect.md
@@ -1,0 +1,7 @@
+---
+"http-proxy-agent": minor
+---
+
+feat(http-proxy-agent): emit 'proxyConnect' event
+
+Adds `proxyConnect` event emission to `http-proxy-agent` for parity with `https-proxy-agent`. The event is emitted on both the request and the agent instance when the socket connects to the proxy server.

--- a/packages/http-proxy-agent/src/index.ts
+++ b/packages/http-proxy-agent/src/index.ts
@@ -9,6 +9,10 @@ import type { OutgoingHttpHeaders } from 'http';
 
 const debug = createDebug('http-proxy-agent');
 
+export interface ProxyConnect {
+	socket: net.Socket;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type Protocol<T> = T extends `${infer Protocol}:${infer _}` ? Protocol : never;
 
@@ -165,6 +169,11 @@ export class HttpProxyAgent<Uri extends string> extends Agent {
 		// important for i.e. `PacProxyAgent` which determines a failed proxy
 		// connection via the `callback()` function throwing.
 		await once(socket, 'connect');
+
+		// Emit the 'proxyConnect' event for parity with https-proxy-agent
+		const connect: ProxyConnect = { socket };
+		req.emit('proxyConnect', connect);
+		this.emit('proxyConnect', connect, req);
 
 		return socket;
 	}

--- a/packages/http-proxy-agent/test/test.ts
+++ b/packages/http-proxy-agent/test/test.ts
@@ -207,6 +207,36 @@ describe('HttpProxyAgent', () => {
 			expect(body.host).toEqual(httpServerUrl.hostname);
 		});
 
+		it('should emit "proxyConnect" event on the request', async () => {
+			httpServer.once('request', (req, res) => {
+				res.end(JSON.stringify(req.headers));
+			});
+
+			const agent = new HttpProxyAgent(proxyUrl);
+
+			const r = req(httpServerUrl, { agent });
+			const [connect] = await once(r, 'proxyConnect');
+			expect(connect.socket).toBeDefined();
+			expect(connect.socket.remoteAddress).toBeDefined();
+			const res = await r;
+			expect(res.statusCode).toEqual(200);
+		});
+
+		it('should emit "proxyConnect" event on the agent', async () => {
+			httpServer.once('request', (req, res) => {
+				res.end(JSON.stringify(req.headers));
+			});
+
+			const agent = new HttpProxyAgent(proxyUrl);
+
+			const r = req(httpServerUrl, { agent });
+			const [connect] = await once(agent, 'proxyConnect');
+			expect(connect.socket).toBeDefined();
+			expect(connect.socket.remoteAddress).toBeDefined();
+			const res = await r;
+			expect(res.statusCode).toEqual(200);
+		});
+
 		it('should work with `keepAlive: true`', async () => {
 			httpServer.on('request', (req, res) => {
 				res.end(JSON.stringify(req.headers));


### PR DESCRIPTION
## Summary

Fixes #368 - Emit the `proxyConnect` event for `http-proxy-agent` for parity with `https-proxy-agent`.

This PR adds `proxyConnect` event emission to `http-proxy-agent`. The event is emitted on both the request and the agent instance when the socket connects to the proxy server.

## Changes

- Added `ProxyConnect` interface with `socket` property
- Emit `proxyConnect` event on the request after socket connects
- Emit `proxyConnect` event on the agent instance after socket connects
- Added test cases for both event emissions

## Event Payload

Since `http-proxy-agent` doesn't use the CONNECT method (it sends requests directly through the proxy), the event payload is different from `https-proxy-agent`. The payload includes:

```typescript
interface ProxyConnect {
  socket: net.Socket;
}
```

This gives users access to the connected socket so they can inspect connection details like `remoteAddress`, `localPort`, etc.

## Usage Example

```typescript
import { HttpProxyAgent } from 'http-proxy-agent';

const agent = new HttpProxyAgent('http://proxy:8080');

// Listen on the request
const req = http.request(url, { agent });
req.on('proxyConnect', (connect) => {
  console.log('Connected to proxy:', connect.socket.remoteAddress);
});

// Or listen on the agent
agent.on('proxyConnect', (connect, req) => {
  console.log('Proxy connection established');
});
```

## Test Cases

- `should emit "proxyConnect" event on the request`
- `should emit "proxyConnect" event on the agent`