### PR TITLE
fix(proxy): prevent DoS via excessively long URLs

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -98,6 +98,14 @@ async function onrequest(
 	}
 
 	socket.resume();
+
+	// Reject excessively long URLs to prevent potential DoS
+	if (req.url && req.url.length > 4096) {
+		res.writeHead(414);
+		res.end();
+		return;
+	}
+
 	const parsed = url.parse(req.url || '/');
 
 	// setup outbound proxy request HTTP headers
@@ -411,6 +419,16 @@ async function onconnect(
 
 	if (!req.url) {
 		throw new TypeError('No "url" provided');
+	}
+
+	// Reject excessively long URLs to prevent potential DoS
+	if (req.url.length > 4096) {
+		debug.response('HTTP/1.1 414 URI Too Long');
+		if (res) {
+			res.writeHead(414);
+			res.end();
+		}
+		return;
 	}
 
 	// `req.url` should look like "example.com:443"

--- a/packages/proxy/test/test.ts
+++ b/packages/proxy/test/test.ts
@@ -145,6 +145,42 @@ describe('proxy', () => {
 		socket.destroy();
 	});
 
+	describe('URL length validation', () => {
+		it('should reject HTTP requests with excessively long URLs', async () => {
+			const socket = net.connect({ port: +proxyUrl.port });
+			await once(socket, 'connect');
+
+			const longHost = 'a'.repeat(5000);
+			socket.write(
+				`GET http://${longHost}/ HTTP/1.1\r\n` +
+					`Host: ${longHost}\r\n` +
+					'\r\n'
+			);
+
+			socket.setEncoding('utf8');
+			const [data] = await once(socket, 'data');
+			assert(0 == data.indexOf('HTTP/1.1 414'));
+			socket.destroy();
+		});
+
+		it('should reject CONNECT requests with excessively long URLs', async () => {
+			const socket = net.connect({ port: +proxyUrl.port });
+			await once(socket, 'connect');
+
+			const longHost = 'a'.repeat(5000);
+			socket.write(
+				`CONNECT ${longHost}:443 HTTP/1.1\r\n` +
+					`Host: ${longHost}:443\r\n` +
+					'\r\n'
+			);
+
+			socket.setEncoding('utf8');
+			const [data] = await once(socket, 'data');
+			assert(0 == data.indexOf('HTTP/1.1 414'));
+			socket.destroy();
+		});
+	});
+
 	describe('authentication', () => {
 		beforeAll(() => {
 			delete proxy.authenticate;


### PR DESCRIPTION
## Summary
Prevent potential denial of service by validating URL length before processing in both HTTP request and CONNECT request handlers.

## Problem
The proxy server's request handlers process URLs from incoming requests without any length validation. An attacker could send requests with extremely long URLs (e.g., `'a'.repeat(100000)`) to cause excessive resource consumption during URL parsing and string operations.

This is related to the ReDoS concern raised in #380. While the current codebase uses `lastIndexOf(':')` rather than the vulnerable regex pattern, adding input length validation is a defense-in-depth measure that prevents DoS from excessively long inputs regardless of the parsing method used.

## Solution
Add URL length validation (reject URLs > 4096 characters) in both the `onrequest` and `onconnect` handlers before any URL parsing occurs. Returns HTTP 414 (URI Too Long) for requests exceeding the limit, which aligns with RFC 7231 Section 6.5.12.

The 4096 character limit is consistent with common server implementations and exceeds the maximum valid hostname length (253 characters per RFC 1035).

## Test Plan
- [x] Added test for HTTP GET request with excessively long URL (returns 414)
- [x] Added test for CONNECT request with excessively long URL (returns 414)
- [x] All existing tests pass

Fixes #380