### PR TITLE
fix(http-proxy-agent): add security notice for CVE-2026-3449 in v5

### DIFF
--- a/packages/http-proxy-agent/README.md
+++ b/packages/http-proxy-agent/README.md
@@ -2,6 +2,11 @@ http-proxy-agent
 ================
 ### An HTTP(s) proxy `http.Agent` implementation for HTTP
 
+> **Security Notice:** `http-proxy-agent@5` depends on the vulnerable
+> `@tootallnate/once@2` package ([CVE-2026-3449](https://github.com/advisories/GHSA-vpq2-c234-7xj6)).
+> This dependency was removed in v7+. If you are using v5, please upgrade to v7
+> or later. See [#406](https://github.com/TooTallNate/proxy-agents/issues/406).
+
 This module provides an `http.Agent` implementation that connects to a specified
 HTTP or HTTPS proxy server, and can be used with the built-in `http` module.
 


### PR DESCRIPTION
## Summary
Add a security notice to the `http-proxy-agent` README regarding CVE-2026-3449 (GHSA-vpq2-c234-7xj6) affecting v5 users.

## Problem
`http-proxy-agent@5.0.0` depends on `@tootallnate/once@^2.0.0`, which has a known vulnerability. Despite being outdated, v5 still receives ~28M weekly downloads because it is a transitive dependency of many popular packages.

## Current Status
The `@tootallnate/once` dependency was already removed in `http-proxy-agent@7.0.0`, which uses the Node.js built-in `import { once } from 'events'` instead. The current codebase on `main` is **not affected**.

## Changes
- Added a security notice to the README directing v5 users to upgrade to v7+

## Recommended Additional Actions
Since v5 predates this monorepo and cannot be easily patched here, consider:

1. **Deprecate v5 on npm**: `npm deprecate "http-proxy-agent@5" "v5 has a known vulnerability (CVE-2026-3449). Upgrade to v7+"`
2. **Encourage upstream consumers** (e.g., `hpagent`, `global-agent`) to update their dependency ranges

Users stuck on v5 via transitive dependencies can use overrides as a workaround:

**npm** (`package.json`):
```json
{
  "overrides": {
    "http-proxy-agent": "^7.0.0"
  }
}
```

**yarn** (`package.json`):
```json
{
  "resolutions": {
    "http-proxy-agent": "^7.0.0"
  }
}
```

Fixes #406