### PR TITLE
socks-proxy-agent: trim IPv6 proxy host brackets

### DIFF
--- a/packages/socks-proxy-agent/src/index.ts
+++ b/packages/socks-proxy-agent/src/index.ts
@@ -30,7 +30,7 @@ const setServernameFromNonIpHost = <
 function parseSocksURL(url: URL): { lookup: boolean; proxy: SocksProxy } {
 	let lookup = false;
 	let type: SocksProxy['type'] = 5;
-	const host = url.hostname;
+	const host = url.hostname.replace(/^\[|\]$/g, '');
 
 	// From RFC 1928, Section 3: https://tools.ietf.org/html/rfc1928#section-3
 	// "The SOCKS service is conventionally located on TCP port 1080"

--- a/packages/socks-proxy-agent/test/test.ts
+++ b/packages/socks-proxy-agent/test/test.ts
@@ -90,6 +90,11 @@ describe('SocksProxyAgent', () => {
 			assert.equal(socksServerUrl.hostname, agent.proxy.host);
 			assert.equal(+socksServerUrl.port, agent.proxy.port);
 		});
+		it('should trim brackets from IPv6 literal proxy hosts', () => {
+			const agent = new SocksProxyAgent('socks://[::1]:1080');
+			assert.equal('::1', agent.proxy.host);
+			assert.equal(1080, agent.proxy.port);
+		});
 		it('should respect `timeout` option during connection to socks server', async () => {
 			const agent = new SocksProxyAgent(socksServerUrl, { timeout: 1 });
 


### PR DESCRIPTION
## Summary
- normalize bracketed IPv6 literal hosts when parsing SOCKS proxy URLs
- add a constructor regression test for `socks://[::1]:1080`

Fixes #437

## Verification
- `pnpm --filter agent-base build`
- `pnpm --filter socks-proxy-agent test`
- `pnpm --filter socks-proxy-agent build`
- `pnpm --filter socks-proxy-agent lint`
- `git diff --cached --check`