### PR TITLE
fix(agent-base): dispatch queued requests after connection failures

### DIFF
--- a/.changeset/calm-requests-drain.md
+++ b/.changeset/calm-requests-drain.md
@@ -1,0 +1,5 @@
+---
+'agent-base': patch
+---
+
+Dispatch queued requests after an asynchronous connection attempt fails.

--- a/packages/agent-base/src/index.ts
+++ b/packages/agent-base/src/index.ts
@@ -122,6 +122,55 @@ export abstract class Agent extends http.Agent {
 		}
 	}
 
+	private drainRequests(
+		failedReq: http.ClientRequest,
+		name: string,
+		options: AgentConnectOpts
+	) {
+		const queue = this.requests[name];
+		if (!queue || queue.length === 0) {
+			return;
+		}
+
+		const failedIndex = queue.indexOf(failedReq);
+		if (failedIndex !== -1) {
+			queue.splice(failedIndex, 1);
+		}
+		if (queue.length === 0) {
+			// @ts-expect-error `requests` is readonly in `@types/node`
+			delete this.requests[name];
+			return;
+		}
+
+		const socketCount = this.sockets[name]?.length ?? 0;
+		// @ts-expect-error `totalSocketCount` isn't defined in `@types/node`
+		const totalSocketCount = this.totalSocketCount;
+		if (
+			socketCount >= this.maxSockets ||
+			totalSocketCount >= this.maxTotalSockets
+		) {
+			return;
+		}
+
+		const nextReq = queue.shift();
+		if (!nextReq) {
+			return;
+		}
+		if (queue.length === 0) {
+			// @ts-expect-error `requests` is readonly in `@types/node`
+			delete this.requests[name];
+		}
+
+		this.createSocket(nextReq, options, (err, socket) => {
+			if (err) {
+				// @ts-expect-error the error overload is missing from `@types/node`
+				nextReq.onSocket(null, err);
+			} else {
+				nextReq.onSocket(socket as net.Socket);
+			}
+		});
+	}
+
 	// In order to properly update the socket pool, we need to call `getName()` on
 	// the core `https.Agent` if it is a secureEndpoint.
 	getName(options?: AgentConnectOpts): string {
@@ -169,6 +218,7 @@ export abstract class Agent extends http.Agent {
 				},
 				(err) => {
 					this.decrementSockets(name, fakeSocket);
+					this.drainRequests(req, name, connectOpts);
 					cb(err);
 				}
 			);

--- a/packages/agent-base/test/test.ts
+++ b/packages/agent-base/test/test.ts
@@ -363,6 +363,33 @@ describe('Agent (TypeScript)', () => {
 				server.close();
 			}
 		});
+
+		it('should dispatch queued requests when `connect()` rejects', async () => {
+			let connectCount = 0;
+
+			class FailingAgent extends Agent {
+				async connect() {
+					connectCount++;
+					throw new Error('simulated connection failure');
+				}
+			}
+
+			const agent = new FailingAgent({ maxSockets: 2 });
+			const errors = Array.from(
+				{ length: 4 },
+				(_, index) =>
+					new Promise<Error>((resolve) => {
+						http.get(`http://example.invalid/${index}`, {
+							agent,
+						}).once('error', resolve);
+					})
+			);
+
+			await Promise.all(errors.slice(0, 2));
+			expect(connectCount).toEqual(4);
+			await expect(Promise.all(errors)).resolves.toHaveLength(4);
+			agent.destroy();
+		});
 	});
 
 	describe('"https" module', () => {


### PR DESCRIPTION
## Summary

- dispatch the next same-origin queued request after an asynchronous Agent connection failure releases socket capacity
- add deterministic regression coverage for repeated connection failures with `maxSockets: 2`
- add a patch changeset for `agent-base`

Fixes #427.

## Problem

When an asynchronous Agent connection attempt rejects, Agent Base removes its placeholder socket but does not enter Node's normal socket-close queue-draining lifecycle.

With four same-origin requests and `maxSockets: 2`, the first two connection attempts reject while the other two requests remain queued indefinitely.

## Change

After removing the failed placeholder, dispatch the next same-origin queued request when capacity is available. Requests are shifted before dispatch, so repeated failures drain the queue without redispatching the same request.

## Validation

- focused issue regression on Node 24 — passed
- Agent Base package suite on Node 24 — 17/17 passed
- Agent Base package suite on Node 22.16 — 17/17 passed
- TypeScript build — passed
- ESLint — passed
- targeted Prettier validation — passed
- changeset validation — passed
- `git show --check` — passed

Node 20 was not tested locally because it is not installed.

The aggregate Turbo command resolves global pnpm 11.14 instead of the repository-pinned pnpm 10.30.3. Repository-wide formatting also reports 123 existing Windows CRLF differences. All changed files pass their targeted validation.

A separate PAC test fixture is locally protected with `skip-worktree` because Windows Defender blocks access. That fixture is unrelated to this change and is absent from the commit and pull-request diff.

## Compatibility

No public API, Node support, dependency, lockfile, or TypeScript declaration change is included.
