### PR TITLE
[http-proxy-agent] Set default SNI for HTTPS proxy servers

### DIFF
--- a/packages/http-proxy-agent/src/index.ts
+++ b/packages/http-proxy-agent/src/index.ts
@@ -17,6 +17,25 @@ export type { OnProxyAuthCallback, ProxyAuthParams, ProxyAuthResponse };
 
 const debug = createDebug('http-proxy-agent');
 
+const setServernameFromNonIpHost = <
+	T extends { host?: string; servername?: string }
+>(
+	options: T
+) => {
+	if (
+		options.servername === undefined &&
+		options.host &&
+		!net.isIP(options.host)
+	) {
+		return {
+			...options,
+			servername: options.host,
+		};
+	}
+	return options;
+};
+
+
 export interface ProxyConnect {
 	socket: net.Socket;
 }
@@ -177,7 +196,7 @@ export class HttpProxyAgent<Uri extends string> extends Agent {
 		let socket: net.Socket;
 		if (this.proxy.protocol === 'https:') {
 			debug('Creating `tls.Socket`: %o', this.connectOpts);
-			socket = tls.connect(this.connectOpts);
+			socket = tls.connect(setServernameFromNonIpHost(this.connectOpts));
 		} else {
 			debug('Creating `net.Socket`: %o', this.connectOpts);
 			socket = net.connect(this.connectOpts);

--- a/packages/http-proxy-agent/test/test.ts
+++ b/packages/http-proxy-agent/test/test.ts
@@ -278,5 +278,30 @@ describe('HttpProxyAgent', () => {
 				agent.destroy();
 			}
 		});
+
+		it('should use the HTTPS proxy hostname as SNI by default', async () => {
+			let receivedServername: string | false | undefined;
+
+			httpServer.once('request', (_req, res) => {
+				res.end();
+			});
+
+			sslProxy.once('secureConnection', (socket) => {
+				receivedServername = socket.servername;
+			});
+
+			const hostnameProxyUrl = new URL(sslProxyUrl);
+			hostnameProxyUrl.hostname = 'localhost';
+
+			const agent = new HttpProxyAgent(hostnameProxyUrl, {
+				rejectUnauthorized: false,
+			});
+
+			const res = await req(httpServerUrl, { agent });
+			res.resume();
+			await once(res, 'end');
+
+			expect(receivedServername).toBe('localhost');
+		});
 	});
 });


### PR DESCRIPTION
When HttpProxyAgent connects to an HTTPS proxy, it calls
tls.connect() with host and port but without servername.

Node.js does not enable SNI automatically for tls.connect(),
so virtual-hosted HTTPS proxies may return their default
certificate and fail certificate validation.

This change defaults servername to the proxy hostname when
the hostname is not an IP address, matching the existing
behavior in https-proxy-agent.